### PR TITLE
Improve performance when using large amount policy

### DIFF
--- a/NetCasbin/CoreEnforcer.cs
+++ b/NetCasbin/CoreEnforcer.cs
@@ -154,8 +154,13 @@ namespace NetCasbin
         /// </summary>
         public void LoadPolicy()
         {
+            if (adapter is null)
+            {
+                return;
+            }
             model.ClearPolicy();
             adapter.LoadPolicy(model);
+            model.RefreshPolicyStringSet();
             if (autoBuildRoleLinks)
             {
                 BuildRoleLinks();
@@ -174,7 +179,7 @@ namespace NetCasbin
             {
                 throw new Exception("filtered policies are not supported by this adapter");
             }
-            (adapter as IFilteredAdapter).LoadFilteredPolicy(model, filter);
+            (adapter as IFilteredAdapter)?.LoadFilteredPolicy(model, filter);
             if (autoBuildRoleLinks)
             {
                 BuildRoleLinks();
@@ -188,9 +193,9 @@ namespace NetCasbin
         /// <returns>if the loaded policy has been filtered.</returns>
         public bool IsFiltered()
         {
-            if (adapter is IFilteredAdapter)
+            if (adapter is IFilteredAdapter filteredAdapter)
             {
-                return (adapter as IFilteredAdapter).IsFiltered;
+                return filteredAdapter.IsFiltered;
             }
             return false;
         }
@@ -397,7 +402,7 @@ namespace NetCasbin
                 {
                     var key = entry.Key;
                     var ast = entry.Value;
-                    var rm = ast.RM;
+                    var rm = ast.RoleManager;
                     functions.Add(key, BuiltInFunctions.GenerateGFunction(key, rm));
                 }
             }

--- a/NetCasbin/Enforcer.cs
+++ b/NetCasbin/Enforcer.cs
@@ -35,11 +35,7 @@ namespace NetCasbin
             fm = FunctionMap.LoadFunctionMap();
 
             Initialize();
-
-            if (this.adapter != null)
-            {
-                LoadPolicy();
-            }
+            LoadPolicy();
         }
 
         public Enforcer(Model.Model m) :
@@ -58,19 +54,19 @@ namespace NetCasbin
 
         public List<string> GetRolesForUser(string name)
         {
-            return model.Model["g"]["g"].RM.GetRoles(name);
+            return model.Model["g"]["g"].RoleManager.GetRoles(name);
         }
 
         public List<string> GetUsersForRole(string name)
         {
-            return model.Model["g"]["g"].RM.GetUsers(name);
+            return model.Model["g"]["g"].RoleManager.GetUsers(name);
         }
 
         public List<string> GetUsersForRoles(string[] names)
         {
             var userIds = new List<string>();
             foreach (var name in names)
-                userIds.AddRange(model.Model["g"]["g"].RM.GetUsers(name));
+                userIds.AddRange(model.Model["g"]["g"].RoleManager.GetUsers(name));
             return userIds;
         }
 
@@ -238,7 +234,7 @@ namespace NetCasbin
 
         public List<string> GetRolesForUserInDomain(string name, string domain)
         {
-            return model.Model["g"]["g"].RM.GetRoles(name, domain);
+            return model.Model["g"]["g"].RoleManager.GetRoles(name, domain);
         }
 
         public List<List<string>> GetPermissionsForUserInDomain(string user, string domain)

--- a/NetCasbin/Model/Assertion.cs
+++ b/NetCasbin/Model/Assertion.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NetCasbin.Util;
 
 namespace NetCasbin.Model
 {
@@ -16,29 +17,33 @@ namespace NetCasbin.Model
 
         public string[] Tokens { set; get; }
 
-        private List<List<string>> _policy;
+        public IRoleManager RoleManager { get; private set; }
 
-        private IRoleManager _rm;
+        public List<List<string>> Policy { set; get; }
 
-        public IRoleManager RM => _rm;
-
-        public List<List<string>> Policy
-        {
-            set => _policy = value;
-            get => _policy;
-        }
+        internal HashSet<string> PolicyStringSet { get; }
 
         public Assertion()
         {
-            _policy = new List<List<string>>();
-            _rm = new DefaultRoleManager(0);
+            Policy = new List<List<string>>();
+            PolicyStringSet = new HashSet<string>();
+            RoleManager = new DefaultRoleManager(0);
         }
 
-        public void BuildRoleLinks(IRoleManager rm)
+        public void RefreshPolicyStringSet()
         {
-            _rm = rm;
+            PolicyStringSet.Clear();
+            foreach (var rule in Policy)
+            {
+                PolicyStringSet.Add(Utility.ArrayToString(rule));
+            }
+        }
+
+        public void BuildRoleLinks(IRoleManager roleManager)
+        {
+            RoleManager = roleManager;
             var count =  Value.ToCharArray().Count(x => x == '_');
-            foreach (var rule in _policy)
+            foreach (var rule in Policy)
             {
                 if (count < 2)
                 {
@@ -51,18 +56,17 @@ namespace NetCasbin.Model
 
                 if (count == 2)
                 {
-                    rm.AddLink(rule[0], rule[1]);
+                    roleManager.AddLink(rule[0], rule[1]);
                 }
                 else if (count == 3)
                 {
-                    rm.AddLink(rule[0], rule[1], rule[2]);
+                    roleManager.AddLink(rule[0], rule[1], rule[2]);
                 }
                 else if (count == 4)
                 {
-                    rm.AddLink(rule[0], rule[1], rule[2], rule[3]);
+                    roleManager.AddLink(rule[0], rule[1], rule[2], rule[3]);
                 }
             }
-
         }
     }
 }

--- a/NetCasbin/Persist/FileAdapter/DefaultFileAdapter.cs
+++ b/NetCasbin/Persist/FileAdapter/DefaultFileAdapter.cs
@@ -1,10 +1,11 @@
-﻿using NetCasbin.Util;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NetCasbin.Model;
+using NetCasbin.Util;
 
 namespace NetCasbin.Persist.FileAdapter
 {
@@ -85,20 +86,19 @@ namespace NetCasbin.Persist.FileAdapter
             throw new NotImplementedException("not implemented");
         }
 
-        private List<string> GetModelPolicy(Model.Model model, string ptype)
+        private static IEnumerable<string> GetModelPolicy(Model.Model model, string ptype)
         {
             var policy = new List<string>();
-            model.Model[ptype].ToList().ForEach(item =>
+            foreach (var pair in model.Model[ptype])
             {
-                var k = item.Key;
-                var v = item.Value;
-                var p = v.Policy.Select(x => $"{k}, {Utility.ArrayToString(x)}").ToList();
-                policy.AddRange(p);
-            });
+                var key = pair.Key;
+                Assertion value = pair.Value;
+                policy.AddRange(value.Policy.Select(p => $"{key}, {Utility.ArrayToString(p)}"));
+            }
             return policy;
         }
 
-        private void LoadPolicyData(Model.Model model, Helper.LoadPolicyLineHandler<string, Model.Model> handler, StreamReader inputStream)
+        private static void LoadPolicyData(Model.Model model, Helper.LoadPolicyLineHandler<string, Model.Model> handler, StreamReader inputStream)
         {
             while (!inputStream.EndOfStream)
             {
@@ -107,7 +107,7 @@ namespace NetCasbin.Persist.FileAdapter
             }
         }
 
-        private IList<string> ConvertToPolicy(Model.Model model)
+        private IEnumerable<string> ConvertToPolicy(Model.Model model)
         {
             if (_byteArrayInputStream != null && _readOnly)
             {


### PR DESCRIPTION
close #15 

I created a benchmark project and here is a partial result.
``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19645
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.5.20279.10
  [Host]     : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT
  Job-FLOMDT : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT

IterationCount=3  RunStrategy=Throughput  
```
**Before**

|    Method | Times | PolicyCount |          Mean |          Error |        StdDev |           Min |           Max |        Median |
|---------- |------ |------------ |--------------:|---------------:|--------------:|--------------:|--------------:|--------------:|
| **HasPolicy** |  **1000** |         **500** |  **10,247.42 μs** |   **6,711.802 μs** |    **367.897 μs** |   **9,962.09 μs** |  **10,662.64 μs** |  **10,117.51 μs** |
| AddPolicy |  1000 |         500 |  21,597.31 μs |  16,262.479 μs |    891.401 μs |  21,026.57 μs |  22,624.49 μs |  21,140.86 μs |
| **HasPolicy** |  **1000** |        **5000** | **112,204.21 μs** |  **41,008.798 μs** |  **2,247.831 μs** | **109,609.56 μs** | **113,561.52 μs** | **113,441.54 μs** |
| AddPolicy |  1000 |        5000 | 133,846.18 μs | 634,420.055 μs | 34,774.704 μs | 109,086.42 μs | 173,602.98 μs | 118,849.14 μs |

**Now**

|    Method | Times | PolicyCount |       Mean |        Error |     StdDev |        Min |        Max |     Median |
|---------- |------ |------------ |-----------:|-------------:|-----------:|-----------:|-----------:|-----------:|
| **HasPolicy** |  **1000** |         **500** | **601.000 μs** |   **102.551 μs** |  **5.6212 μs** | **596.873 μs** | **607.402 μs** | **598.726 μs** |
| AddPolicy |  1000 |         500 | 632.119 μs |   298.945 μs | 16.3862 μs | 615.599 μs | 648.368 μs | 632.391 μs |
| **HasPolicy** |  **1000** |        **5000** | **645.874 μs** |   **419.625 μs** | **23.0011 μs** | **621.002 μs** | **666.378 μs** | **650.243 μs** |
| AddPolicy |  1000 |        5000 | 627.886 μs |   578.806 μs | 31.7263 μs | 605.511 μs | 664.195 μs | 613.952 μs |