### PR TITLE
provide interface of enforcer to make testing easier

### DIFF
--- a/NetCasbin/CoreEnforcer.cs
+++ b/NetCasbin/CoreEnforcer.cs
@@ -14,7 +14,7 @@ namespace NetCasbin
     /// <summary>
     /// CoreEnforcer defines the core functionality of an enforcer.
     /// </summary>
-    public class CoreEnforcer
+    public class CoreEnforcer : ICoreEnforcer
     {
         private IEffector _effector;
         private bool _enabled;

--- a/NetCasbin/Enforcer.cs
+++ b/NetCasbin/Enforcer.cs
@@ -10,7 +10,7 @@ namespace NetCasbin
     /// <summary>
     /// Enforcer = ManagementEnforcer + RBAC API.
     /// </summary>
-    public class Enforcer : ManagementEnforcer
+    public class Enforcer : ManagementEnforcer, IEnforcer
     {
 
         public Enforcer() : this(string.Empty, string.Empty)

--- a/NetCasbin/ICoreEnforcer.cs
+++ b/NetCasbin/ICoreEnforcer.cs
@@ -1,0 +1,162 @@
+// Copyright 2019 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using NetCasbin.Effect;
+using NetCasbin.Persist;
+using NetCasbin.Rbac;
+
+namespace NetCasbin
+{
+
+    /// <summary>
+    /// ICoreEnforcer is the API interface of CoreEnforcer
+    /// </summary>
+    public interface ICoreEnforcer
+    {
+     
+         /// <summary>
+        /// LoadModel reloads the model from the model CONF file. Because the policy is
+        /// Attached to a model, so the policy is invalidated and needs to be reloaded by
+        /// calling LoadPolicy().
+        /// </summary>
+         void LoadModel();
+        
+        /// <summary>
+        /// Gets the current model.
+        /// </summary>
+        /// <returns>The model of the enforcer.</returns>
+         Model.Model GetModel();
+
+        /// <summary>
+        /// Sets the current model.
+        /// </summary>
+        /// <param name="model"></param>
+         void SetModel(Model.Model model);
+
+        /// <summary>
+        /// Gets the current adapter.
+        /// </summary>
+        /// <returns></returns>
+         IAdapter GetAdapter();
+
+        /// <summary>
+        /// Sets an adapter.
+        /// </summary>
+        /// <param name="adapter"></param>
+         void SetAdapter(IAdapter adapter);
+
+        /// <summary>
+        /// Sets an watcher.
+        /// </summary>
+        /// <param name="watcher"></param>
+        /// <param name="useAsync">Whether use async update callback.</param>
+         void SetWatcher(IWatcher watcher, bool useAsync = true);
+
+        /// <summary>
+        /// Sets the current role manager.
+        /// </summary>
+        /// <param name="roleManager"></param>
+         void SetRoleManager(IRoleManager roleManager);
+
+        /// <summary>
+        /// Sets the current effector.
+        /// </summary>
+        /// <param name="effector"></param>
+         void SetEffector(IEffector effector);
+
+        /// <summary>
+        /// Clears all policy.
+        /// </summary>
+         void ClearPolicy();
+
+        /// <summary>
+        /// Reloads the policy from file/database.
+        /// </summary>
+         void LoadPolicy();
+
+        /// <summary>
+        /// Reloads the policy from file/database.
+        /// </summary>
+        Task LoadPolicyAsync();
+
+        /// <summary>
+        /// Reloads a filtered policy from file/database.
+        /// </summary>
+        /// <param name="filter">The filter used to specify which type of policy should be loaded.</param>
+        /// <returns></returns>
+         bool LoadFilteredPolicy(Filter filter);
+
+        /// <summary>
+        /// Reloads a filtered policy from file/database.
+        /// </summary>
+        /// <param name="filter">The filter used to specify which type of policy should be loaded.</param>
+        /// <returns></returns>
+        Task<bool> LoadFilteredPolicyAsync(Filter filter);
+
+        /// <summary>
+        /// Returns true if the loaded policy has been filtered.
+        /// </summary>
+        /// <returns>if the loaded policy has been filtered.</returns>
+         bool IsFiltered();
+
+        /// <summary>
+        /// Saves the current policy (usually after changed with Casbin API)
+        /// back to file/database.
+        /// </summary>
+         void SavePolicy();
+
+        /// <summary>
+        /// Saves the current policy (usually after changed with Casbin API)
+        /// back to file/database.
+        /// </summary>
+        Task SavePolicyAsync();
+
+        /// <summary>
+        /// Changes the enforcing state of Casbin, when Casbin is disabled,
+        /// all access will be allowed by the enforce() function.
+        /// </summary>
+        /// <param name="enable"></param>
+         void EnableEnforce(bool enable);
+
+        /// <summary>
+        /// Controls whether to save a policy rule automatically to the
+        /// adapter when it is added or removed.
+        /// </summary>
+        /// <param name="autoSave"></param>
+         void EnableAutoSave(bool autoSave);
+
+        /// <summary>
+        /// Controls whether to save a policy rule automatically
+        /// to the adapter when it is added or removed.
+        /// </summary>
+        /// <param name="autoBuildRoleLinks">Whether to automatically build the role links.</param>
+         void EnableAutoBuildRoleLinks(bool autoBuildRoleLinks);
+
+        /// <summary>
+        /// Manually rebuilds the role inheritance relations.
+        /// </summary>
+         void BuildRoleLinks();
+
+        /// <summary>
+        /// Decides whether a "subject" can access a "object" with the operation
+        /// "action", input parameters are usually: (sub, obj, act).
+        /// </summary>
+        /// <param name="rvals">The request needs to be mediated, usually an array of strings, 
+        /// can be class instances if ABAC is used.</param>
+        /// <returns>Whether to allow the request.</returns>
+         bool Enforce(params object[] rvals);
+    }
+
+}

--- a/NetCasbin/IEnforcer.cs
+++ b/NetCasbin/IEnforcer.cs
@@ -1,0 +1,333 @@
+// Copyright 2019 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NetCasbin
+{
+
+    /// <summary>
+    /// IEnforcer is the API interface of Enforcer
+    /// </summary>
+    public interface IEnforcer : IManagementEnforcer
+    {
+
+        /// <summary>
+        /// Gets the roles that a user has.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        List<string> GetRolesForUser(string name);
+
+
+        /// <summary>
+        /// Gets the users that has a role.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        List<string> GetUsersForRole(string name);
+
+        /// <summary>
+        /// Gets the users that has roles.
+        /// </summary>
+        /// <param name="names"></param>
+        /// <returns></returns>
+        List<string> GetUsersForRoles(string[] names);
+
+        /// <summary>
+        /// Determines whether a user has a role.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="role"></param>
+        /// <returns></returns>
+        bool HasRoleForUser(string name, string role);
+
+        /// <summary>
+        /// Adds a role for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <returns>Returns false if the user already has the role (aka not affected).</returns>
+        bool AddRoleForUser(string user, string role);
+
+        /// <summary>
+        /// Adds a role for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <returns>Returns false if the user already has the role (aka not affected).</returns>
+        Task<bool> AddRoleForUserAsync(string user, string role);
+
+        /// <summary>
+        /// Deletes a role for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <returns>Returns false if the user does not have the role (aka not affected).</returns>
+        bool DeleteRoleForUser(string user, string role);
+
+        /// <summary>
+        /// Deletes a role for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <returns>Returns false if the user does not have the role (aka not affected).</returns>
+        Task<bool> DeleteRoleForUserAsync(string user, string role);
+
+        /// <summary>
+        /// Deletes all roles for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns>Returns false if the user does not have any roles (aka not affected).</returns>
+        bool DeleteRolesForUser(string user);
+
+        /// <summary>
+        /// Deletes all roles for a user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns>Returns false if the user does not have any roles (aka not affected).</returns>
+        Task<bool> DeleteRolesForUserAsync(string user);
+
+        /// <summary>
+        /// DeleteUser deletes a user
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns>Returns false if the user does not exist (aka not affected).</returns>
+        bool DeleteUser(string user);
+
+        /// <summary>
+        /// DeleteUser deletes a user
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns>Returns false if the user does not exist (aka not affected).</returns>
+        Task<bool> DeleteUserAsync(string user);
+        /// <summary>
+        /// Deletes a role.
+        /// </summary>
+        /// <param name="role"></param>
+        void DeleteRole(string role);
+
+        /// <summary>
+        /// Deletes a role.
+        /// </summary>
+        /// <param name="role"></param>
+        Task DeleteRoleAsync(string role);
+
+        /// <summary>
+        /// DeletePermission deletes a permission. 
+        /// </summary>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the permission does not exist (aka not affected).</returns>
+        bool DeletePermission(List<string> permission);
+
+        /// <summary>
+        /// DeletePermission deletes a permission. 
+        /// </summary>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the permission does not exist (aka not affected).</returns>
+        Task<bool> DeletePermissionAsync(List<string> permission);
+
+        /// <summary>
+        /// DeletePermission deletes a permission. 
+        /// </summary>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the permission does not exist (aka not affected).</returns>
+        bool DeletePermission(params string[] permission);
+
+        /// <summary>
+        /// DeletePermission deletes a permission. 
+        /// </summary>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the permission does not exist (aka not affected).</returns>
+        Task<bool> DeletePermissionAsync(params string[] permission);
+
+        /// <summary>
+        /// Adds a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the user or role already has the permission (aka not affected).</returns>
+        bool AddPermissionForUser(string user, List<string> permission);
+
+        /// <summary>
+        /// Adds multiple permissions for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the user or role already has the permission (aka not affected).</returns>
+        Task<bool> AddPermissionForUserAsync(string user, List<string> permission);
+
+        /// <summary>
+        /// Adds a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns> Returns false if the user or role already has the permission (aka not affected).</returns>
+        bool AddPermissionForUser(string user, params string[] permission);
+
+        /// <summary>
+        /// Adds a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns> Returns false if the user or role already has the permission (aka not affected).</returns>
+        Task<bool> AddPermissionForUserAsync(string user, params string[] permission);
+
+        /// <summary>
+        /// DeletePermissionForUser deletes a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the user or role does not have any permissions (aka not affected).</returns>
+        bool DeletePermissionForUser(string user, List<string> permission);
+
+        /// <summary>
+        /// DeletePermissionForUser deletes a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns>Returns false if the user or role does not have any permissions (aka not affected).</returns>
+        Task<bool> DeletePermissionForUserAsync(string user, List<string> permission);
+
+        /// <summary>
+        /// DeletePermissionForUser deletes a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns></returns>
+        bool DeletePermissionForUser(string user, params string[] permission);
+
+        /// <summary>
+        /// DeletePermissionForUser deletes a permission for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns></returns>
+        Task<bool> DeletePermissionForUserAsync(string user, params string[] permission);
+
+        /// <summary>
+        /// DeletePermissionsForUser deletes permissions for a user or role. 
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <returns>Returns false if the user or role does not have any permissions (aka not affected).</returns>
+        bool DeletePermissionsForUser(string user);
+
+        /// <summary>
+        /// DeletePermissionsForUser deletes permissions for a user or role. 
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <returns>Returns false if the user or role does not have any permissions (aka not affected).</returns>
+        Task<bool> DeletePermissionsForUserAsync(string user);
+
+        /// <summary>
+        /// Gets permissions for a user or role.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <returns></returns>
+        List<List<string>> GetPermissionsForUser(string user);
+
+        /// <summary>
+        /// Determines whether a user has a permission.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns></returns>
+        bool HasPermissionForUser(string user, params string[] permission);
+
+        /// <summary>
+        /// Determines whether a user has a permission.
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="permission"></param>
+        /// <returns></returns>
+        bool HasPermissionForUser(string user, List<string> permission);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        List<string> GetRolesForUserInDomain(string name, string domain);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        List<List<string>> GetPermissionsForUserInDomain(string user, string domain);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        bool AddRoleForUserInDomain(string user, string role, string domain);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        Task<bool> AddRoleForUserInDomainAsync(string user, string role, string domain);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        bool DeleteRoleForUserInDomain(string user, string role, string domain);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="role"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        Task<bool> DeleteRoleForUserInDomainAsync(string user, string role, string domain);
+
+        /// <summary>
+        /// Gets implicit roles that a user has.
+        /// Compared to GetRolesForUser(), this function retrieves indirect roles besides direct roles.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        List<string> GetImplicitRolesForUser(string name, params string[] domain);
+        /// <summary>
+        /// <para>Gets implicit permissions for a user or role.</para>
+        /// <para>Compared to GetPermissionsForUser(), this function retrieves permissions for inherited roles.</para> 
+        /// <para>For example:</para>
+        /// <para>p, admin, data1, read</para>
+        /// <para>p, alice, data2, read</para>
+        /// <para>g, alice, admin </para>
+        /// <para>GetPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].</para>
+        /// <para>But GetImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].</para>
+        /// </summary>
+        /// <param name="user">User or role</param>
+        /// <returns></returns>
+        List<List<string>> GetImplicitPermissionsForUser(string user);
+
+    }
+
+}

--- a/NetCasbin/IManagementEnforcer.cs
+++ b/NetCasbin/IManagementEnforcer.cs
@@ -1,0 +1,578 @@
+// Copyright 2019 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NetCasbin
+{
+
+    /// <summary>
+    /// IManagementEnforcer is the API interface of ManagementEnforcer
+    /// </summary>
+    public interface IManagementEnforcer : ICoreEnforcer
+    {
+
+
+        /// <summary>
+        /// Gets the list of subjects that show up in the current policy.
+        /// </summary>
+        /// <returns>
+        /// All the subjects in "p" policy rules. It actually collects the
+        /// 0-index elements of "p" policy rules. So make sure your subject
+        /// is the 0-index element, like (sub, obj, act). Duplicates are removed.
+        /// </returns>
+         List<string> GetAllSubjects();
+
+        /// <summary>
+        /// GetAllNamedSubjects gets the list of subjects that show up in the currentnamed policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <returns>
+        /// All the subjects in policy rules of the ptype type. It actually
+        /// collects the 0-index elements of the policy rules.So make sure
+        /// your subject is the 0-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllNamedSubjects(string ptype);
+
+        /// <summary>
+        /// Gets the list of objects that show up in the current policy.
+        /// </summary>
+        /// <returns>
+        /// All the objects in "p" policy rules. It actually collects the
+        /// 1-index elements of "p" policy rules.So make sure your object
+        /// is the 1-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllObjects();
+
+        /// <summary>
+        /// Gets the list of objects that show up in the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <returns>
+        /// All the objects in policy rules of the ptype type. It actually
+        /// collects the 1-index elements of the policy rules.So make sure
+        /// your object is the 1-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllNamedObjects(string ptype);
+
+        /// <summary>
+        /// Gets the list of actions that show up in the current policy.
+        /// </summary>
+        /// <returns>
+        /// All the actions in "p" policy rules. It actually collects
+        /// the 2-index elements of "p" policy rules.So make sure your action
+        /// is the 2-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllActions();
+
+        /// <summary>
+        /// Gets the list of actions that show up in the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <returns>
+        /// All the actions in policy rules of the ptype type. It actually
+        /// collects the 2-index elements of the policy rules.So make sure
+        /// your action is the 2-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllNamedActions(string ptype);
+
+        /// <summary>
+        /// Gets the list of roles that show up in the current policy.
+        /// </summary>
+        /// <returns>
+        /// All the roles in "g" policy rules. It actually collects
+        /// the 1-index elements of "g" policy rules. So make sure your
+        /// role is the 1-index element, like (sub, role).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllRoles();
+
+        /// <summary>
+        /// Gets the list of roles that show up in the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <returns>
+        /// All the subjects in policy rules of the ptype type. It actually
+        /// collects the 0-index elements of the policy rules.So make
+        /// Sure your subject is the 0-index element, like (sub, obj, act).
+        /// Duplicates are removed.</returns>
+         List<string> GetAllNamedRoles(string ptype);
+
+        /// <summary>
+        /// Gets all the authorization rules in the policy.
+        /// </summary>
+        /// <returns> all the "p" policy rules.</returns>
+         List<List<string>> GetPolicy();
+
+        /// <summary>
+        /// Gets all the authorization rules in the policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to  match this field.</param>
+        /// <returns>The filtered "p" policy rules.</returns>
+         List<List<string>> GetFilteredPolicy(int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Gets all the authorization rules in the named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <returns>The "p" policy rules of the specified ptype.</returns>
+         List<List<string>> GetNamedPolicy(string ptype);
+
+        /// <summary>
+        /// Gets all the authorization rules in the named policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to  match this field.</param>
+        /// <returns>The filtered "p" policy rules of the specified ptype.</returns>
+         List<List<string>> GetFilteredNamedPolicy(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Gets all the role inheritance rules in the policy.
+        /// </summary>
+        /// <returns>all the "g" policy rules.</returns>
+         List<List<string>> GetGroupingPolicy();
+
+        /// <summary>
+        /// Gets all the role inheritance rules in the policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>The filtered "g" policy rules.</returns>
+         List<List<string>> GetFilteredGroupingPolicy(int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Gets all the role inheritance rules in the policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <returns>The "g" policy rules of the specified ptype.</returns>
+         List<List<string>> GetNamedGroupingPolicy(string ptype);
+
+        /// <summary>
+        /// Gets all the role inheritance rules in the policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>The filtered "g" policy rules of the specified ptype.</returns>
+         List<List<string>> GetFilteredNamedGroupingPolicy(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Determines whether an authorization rule exists.
+        /// </summary>
+        /// <param name="paramList">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasPolicy(List<string> paramList);
+
+        /// <summary>
+        /// Determines whether an authorization rule exists.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasPolicy(params string[] parameters);
+
+        /// <summary>
+        /// Determines whether a named authorization rule exists.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="paramList">The "p" policy rule.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasNamedPolicy(string ptype, List<string> paramList);
+
+        /// <summary>
+        /// Determines whether a named authorization rule exists.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasNamedPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current policy. If the rule
+        /// already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddPolicy(params string[] parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current policy. If the rule
+        /// already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddPolicyAsync(params string[] parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current policy. If the rule
+        /// already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddPolicy(List<string> parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current policy. If the rule
+        /// already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddPolicyAsync(List<string> parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current named policy.If the
+        /// rule already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddNamedPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current named policy.If the
+        /// rule already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddNamedPolicyAsync(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current named policy.If the
+        /// rule already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddNamedPolicy(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Adds an authorization rule to the current named policy.If the
+        /// rule already exists, the function returns false and the rule will not be added.
+        /// Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddNamedPolicyAsync(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemovePolicy(params string[] parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemovePolicyAsync(params string[] parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemovePolicy(List<string> parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "p" policy rule, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemovePolicyAsync(List<string> parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveFilteredPolicy(int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Removes an authorization rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveFilteredPolicyAsync(int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveNamedPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveNamedPolicyAsync(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveNamedPolicy(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="parameters">The "p" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveNamedPolicyAsync(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to  match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveFilteredNamedPolicy(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Removes an authorization rule from the current named policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to  match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveFilteredNamedPolicyAsync(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Determines whether a role inheritance rule exists.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasGroupingPolicy(List<string> parameters);
+
+        /// <summary>
+        /// Determines whether a role inheritance rule exists.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasGroupingPolicy(params string[] parameters);
+
+        /// <summary>
+        /// Determines whether a named role inheritance rule
+        /// exists.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasNamedGroupingPolicy(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Determines whether a named role inheritance rule
+        /// exists.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule.</param>
+        /// <returns>Whether the rule exists.</returns>
+         bool HasNamedGroupingPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Adds a role inheritance rule to the current policy. If the
+        /// rule already exists, the function returns false and the rule will not be
+        /// Added.Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddGroupingPolicy(params string[] parameters);
+
+        /// <summary>
+        /// Adds a role inheritance rule to the current policy. If the
+        /// rule already exists, the function returns false and the rule will not be
+        /// Added.Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddGroupingPolicyAsync(params string[] parameters);
+
+        /// <summary>
+        /// Adds a role inheritance rule to the current policy. If the
+        /// rule already exists, the function returns false and the rule will not be
+        /// Added.Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddGroupingPolicy(List<string> parameters);
+
+        /// <summary>
+        /// Adds a role inheritance rule to the current policy. If the
+        /// rule already exists, the function returns false and the rule will not be
+        /// Added.Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddGroupingPolicyAsync(List<string> parameters);
+
+        /// <summary>
+        /// Adds a named role inheritance rule to the current 
+        /// policy. If the rule already exists, the function returns false and the rule
+        /// will not be added. Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddNamedGroupingPolicy(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Adds a named role inheritance rule to the current 
+        /// policy. If the rule already exists, the function returns false and the rule
+        /// will not be added. Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> AddNamedGroupingPolicyAsync(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Adds a named role inheritance rule to the current 
+        /// policy. If the rule already exists, the function returns false and the rule
+        /// will not be added. Otherwise the function returns true by adding the new rule.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool AddNamedGroupingPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveGroupingPolicy(params string[] parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveGroupingPolicyAsync(params string[] parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveGroupingPolicy(List<string> parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveGroupingPolicyAsync(List<string> parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveNamedGroupingPolicy(string ptype, params string[] parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveNamedGroupingPolicyAsync(string ptype, params string[] parameters);
+
+                /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveNamedGroupingPolicy(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="parameters">The "g" policy rule, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveNamedGroupingPolicyAsync(string ptype, List<string> parameters);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveFilteredGroupingPolicy(int fieldIndex, params string[] fieldValues);
+        
+        /// <summary>
+        /// Removes a role inheritance rule from the current 
+        /// policy, field filters can be specified.
+        /// </summary>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveFilteredGroupingPolicyAsync(int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current named policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         bool RemoveFilteredNamedGroupingPolicy(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Removes a role inheritance rule from the current named policy, field filters can be specified.
+        /// </summary>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="fieldIndex">The policy rule's start index to be matched.</param>
+        /// <param name="fieldValues">The field values to be matched, value "" means not to match this field.</param>
+        /// <returns>Succeeds or not.</returns>
+         Task<bool> RemoveFilteredNamedGroupingPolicyAsync(string ptype, int fieldIndex, params string[] fieldValues);
+
+        /// <summary>
+        /// Adds a customized function.
+        /// </summary>
+        /// <param name="name">The name of the new function.</param>
+        /// <param name="function">The function.</param>
+         void AddFunction(string name, AbstractFunction function);
+    }
+
+}

--- a/NetCasbin/ManagementEnforcer.cs
+++ b/NetCasbin/ManagementEnforcer.cs
@@ -9,7 +9,7 @@ namespace NetCasbin
     /// <summary>
     /// ManagementEnforcer = InternalEnforcer + Management API.
     /// </summary>
-    public class ManagementEnforcer : InternalEnforcer
+    public class ManagementEnforcer : InternalEnforcer, IManagementEnforcer
     {
         /// <summary>
         /// Gets the list of subjects that show up in the current policy.


### PR DESCRIPTION
Make testing for Casbin.NET easier. So you do not need write complex arranges in your unit tests, use a adapter which will change the test to an integration test or wrapping the enforcer. 

- introduce interface for IEnforcer 
- introduce interface for IManagementEnforcer
- introduce interface for ICoreEnforcer 
