### PR TITLE
Improve KeyMatch4 function performence

### DIFF
--- a/Casbin.Benchmark/BuildInFunctionsBenchmark.cs
+++ b/Casbin.Benchmark/BuildInFunctionsBenchmark.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using NetCasbin.Util;
+
+namespace Casbin.Benchmark
+{
+    [MemoryDiagnoser]
+    [BenchmarkCategory("Functions")]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.Net48)]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.NetCoreApp31, baseline: true)]
+    public class BuildInFunctionsBenchmark
+    {
+        public IEnumerable<object[]> KeyMatch4TestData() => new[]
+        {
+            new object[] {"/parent/123/child/123", "/parent/{id}/child/{id}"},
+            new object[] {"/parent/123/child/123", "/parent/{id}/child/{another_id}"}
+        };
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(KeyMatch4))]
+        [ArgumentsSource(nameof(KeyMatch4TestData))]
+        public void KeyMatch4(string key1, string key2)
+        {
+            _ = BuiltInFunctions.KeyMatch4(key2, key2);
+        }
+    }
+}

--- a/NetCasbin/Util/BuiltInFunctions.cs
+++ b/NetCasbin/Util/BuiltInFunctions.cs
@@ -91,24 +91,22 @@ namespace NetCasbin.Util
         /// Besides what KeyMatch3 does, KeyMatch4 can also match repeated patterns:
         /// "/parent/123/child/123" matches "/parent/{id}/child/{id}"
         /// "/parent/123/child/456" does not match "/parent/{id}/child/{id}"
-        /// </summary>
         /// But KeyMatch3 will match both.
+        /// </summary>
         /// <param name="key1">The first argument.</param>
         /// <param name="key2">The second argument.</param>
         /// <returns>Whether key1 matches key2.</returns>
         public static bool KeyMatch4(string key1, string key2)
         {
             key2 = key2.Replace("/*", "/.*");
-            var key2Match = s_keyMatch4Regex.Match(key2);
 
             var tokens = new List<string>();
 
-            while (key2Match.Success)
+            key2 = s_keyMatch4Regex.Replace(key2, match =>
             {
-                key2 = s_keyMatch4Regex.Replace(key2, "([^/]+)");
-                tokens.Add(key2Match.Value.Substring(1, key2Match.Value.Length - 2));
-                key2Match = key2Match.NextMatch();
-            }
+                tokens.Add(match.Value.Substring(1, match.Value.Length - 2));
+                return "([^/]+)";
+            });
 
             var valueRegex = new Regex($"^{key2}$");
             var key1Match =  valueRegex.Match(key1);


### PR DESCRIPTION

|       Method |        Job |       Runtime |                 key1 |                 key2 |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |----------- |-------------- |--------------------- |--------------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|    **KeyMatch4** | **Job-SZGZJN** |      **.NET 4.8** | **/pare(...)d/123 [21]** | **/pare(...)r_id} [31]** | **19.03 μs** | **1.018 μs** | **0.673 μs** |  **1.19** |    **0.04** | **3.4180** |     **-** |     **-** |  **10.52 KB** |
|    KeyMatch4 | Job-ZPYDIF | .NET Core 3.1 | /pare(...)d/123 [21] | /pare(...)r_id} [31] | 16.05 μs | 0.549 μs | 0.363 μs |  1.00 |    0.00 | 2.7161 |     - |     - |   8.37 KB |
|              |            |               |                      |                      |          |          |          |       |         |        |       |       |           |
|    **KeyMatch4 (Current)** | **Job-QHVCPX** |      **.NET 4.8** | **/pare(...)d/123 [21]** | **/pare(...)r_id} [31]** | **17.87 μs** | **0.371 μs** | **0.221 μs** |  **1.27** |    **0.04** | **3.2654** |     **-** |     **-** |  **10.12 KB** |
|    KeyMatch4 (Current)| Job-PGTUJQ | .NET Core 3.1 | /pare(...)d/123 [21] | /pare(...)r_id} [31] | 14.07 μs | 0.584 μs | 0.386 μs |  1.00 |    0.00 | 2.5940 |     - |     - |   7.98 KB |
|              |            |               |                      |                      |          |          |          |       |         |        |       |       |           |
|    **KeyMatch4 ** | **Job-SZGZJN** |      **.NET 4.8** | **/pare(...)d/123 [21]** | **/pare(...)/{id} [23]** | **20.10 μs** | **0.561 μs** | **0.371 μs** |  **1.15** |    **0.05** | **3.3875** |     **-** |     **-** |  **10.45 KB** |
|    KeyMatch4 | Job-ZPYDIF | .NET Core 3.1 | /pare(...)d/123 [21] | /pare(...)/{id} [23] | 17.50 μs | 0.792 μs | 0.524 μs |  1.00 |    0.00 | 2.6855 |     - |     - |    8.3 KB |
|              |            |               |                      |                      |          |          |          |       |         |        |       |       |           |
|    **KeyMatch4 (Current)** | **Job-QHVCPX** |      **.NET 4.8** | **/pare(...)d/123 [21]** | **/pare(...)/{id} [23]** | **17.56 μs** | **1.004 μs** | **0.664 μs** |  **1.28** |    **0.03** | **3.2654** |     **-** |     **-** |  **10.06 KB** |
|    KeyMatch4 (Current) | Job-PGTUJQ | .NET Core 3.1 | /pare(...)d/123 [21] | /pare(...)/{id} [23] | 13.79 μs | 0.288 μs | 0.171 μs |  1.00 |    0.00 | 2.5635 |     - |     - |   7.91 KB |