### PR TITLE
Fix IPMatch error and improve performance of it

### DIFF
--- a/Casbin.Benchmark/BuildInFunctionsBenchmark.cs
+++ b/Casbin.Benchmark/BuildInFunctionsBenchmark.cs
@@ -23,7 +23,21 @@ namespace Casbin.Benchmark
         [ArgumentsSource(nameof(KeyMatch4TestData))]
         public void KeyMatch4(string key1, string key2)
         {
-            _ = BuiltInFunctions.KeyMatch4(key2, key2);
+            _ = BuiltInFunctions.KeyMatch4(key1, key2);
+        }
+
+        public IEnumerable<object[]> IPMatchTestData() => new[]
+        {
+            new object[] {"192.168.2.123", "192.168.2.123"},
+            new object[] {"192.168.2.123", "192.168.2.0/24"}
+        };
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(IPMatch))]
+        [ArgumentsSource(nameof(IPMatchTestData))]
+        public void IPMatch(string key1, string key2)
+        {
+            _ = BuiltInFunctions.IPMatch(key1, key2);
         }
     }
 }

--- a/NetCasbin.UnitTest/BuiltInFunctionTest.cs
+++ b/NetCasbin.UnitTest/BuiltInFunctionTest.cs
@@ -6,6 +6,25 @@ namespace NetCasbin.UnitTest
 {
     public class BuiltInFunctionTest
     {
+        public static IEnumerable<object[]> ipMatchTestData = new[]
+        {
+            new object[] {"192.168.2.123", "192.168.2.0/24", true},
+            new object[] {"192.168.2.123", "192.168.3.0/24", false},
+            new object[] {"192.168.2.123", "192.168.2.0/16", true},
+            new object[] {"192.168.2.123", "192.168.2.123", true},
+            new object[] {"192.168.2.123", "192.168.2.123/32", true},
+            new object[] {"10.0.0.11", "10.0.0.0/8", true},
+            new object[] {"11.0.0.123", "10.0.0.0/8", false}
+        };
+
+        [Theory]
+        [MemberData(nameof(ipMatchTestData))]
+        public void TestIPMatch(string key1, string key2, bool exceptResult)
+        {
+            Assert.Equal(exceptResult,
+                BuiltInFunctions.IPMatch(key1, key2));
+        }
+
         public static IEnumerable<object[]> regexMatchTestData = new[]
         {
             new object[] {"/topic/create", "/topic/create", true},

--- a/NetCasbin/Model/FunctionMap.cs
+++ b/NetCasbin/Model/FunctionMap.cs
@@ -25,7 +25,7 @@ namespace NetCasbin.Model
             map.AddFunction("keyMatch3", new KeyMatch3Func());
             map.AddFunction("keyMatch4", new KeyMatch4Func());
             map.AddFunction("regexMatch", new RegexMatchFunc());
-            map.AddFunction("ipMatch", new IpMatchFunc());
+            map.AddFunction("ipMatch", new IPMatchFunc());
             return map;
         }
     }

--- a/NetCasbin/NetCasbin.csproj
+++ b/NetCasbin/NetCasbin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicExpresso.Core" Version="2.3.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCasbin/Util/Function/IPMatchFunc.cs
+++ b/NetCasbin/Util/Function/IPMatchFunc.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Net;
 using NetCasbin.Abstractions;
 
 namespace NetCasbin.Util.Function
 {
-    public class IpMatchFunc : AbstractFunction
+    public class IPMatchFunc : AbstractFunction
     {
         protected override Delegate GetFunc()
         {
-            Func<string, string, bool> call = BuiltInFunctions.IpMatch;
+            Func<string, string, bool> call = BuiltInFunctions.IPMatch;
             return call;
         }
 
-        public IpMatchFunc() : base("ipMatch")
+        public IPMatchFunc() : base("ipMatch")
         {
 
         }


### PR DESCRIPTION
close:  #85 

There are performance changes, The new version's `Mean` is nearly 6690% times shorter than the old version and the allocation is about 12228% times less.
 ```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20201
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.8.20417.9
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  Job-ENGJLM : .NET Framework 4.8 (4.8.4210.0), X64 RyuJIT
  Job-VTJFVJ : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

IterationCount=10  RunStrategy=Throughput  
```
Old :
|  Method |        Job |       Runtime |          key1 |           key2 |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |----------- |-------------- |-------------- |--------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| **IPMatch** | **Job-ENGJLM** |      **.NET 4.8** | **192.168.2.123** | **192.168.2.0/24** | **25.52 μs** | **3.348 μs** | **1.992 μs** |  **1.21** |    **0.08** | **7.5989** |     **-** |     **-** |   **23.4 KB** |
| IPMatch | Job-VTJFVJ | .NET Core 3.1 | 192.168.2.123 | 192.168.2.0/24 | 21.04 μs | 1.301 μs | 0.860 μs |  1.00 |    0.00 | 6.3782 |     - |     - |  19.58 KB |
|         |            |               |               |                |          |          |          |       |         |        |       |       |           |
| **IPMatch** | **Job-ENGJLM** |      **.NET 4.8** | **192.168.2.123** |  **192.168.2.123** | **24.02 μs** | **1.850 μs** | **1.223 μs** |  **1.14** |    **0.10** | **7.4768** |     **-** |     **-** |     **23 KB** |
| IPMatch | Job-VTJFVJ | .NET Core 3.1 | 192.168.2.123 |  192.168.2.123 | 21.26 μs | 2.381 μs | 1.575 μs |  1.00 |    0.00 | 6.2866 |     - |     - |  19.29 KB |

New :
|  Method |        Job |       Runtime |          key1 |           key2 |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |----------- |-------------- |-------------- |--------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| **IPMatch** | **Job-TYLCCQ** |      **.NET 4.8** | **192.168.2.123** | **192.168.2.0/24** | **447.8 ns** | **19.99 ns** | **11.90 ns** |  **1.41** |    **0.07** | **0.1221** |     **-** |     **-** |     **385 B** |
| IPMatch | Job-YTCUUC | .NET Core 3.1 | 192.168.2.123 | 192.168.2.0/24 | 315.5 ns | 24.02 ns | 15.89 ns |  1.00 |    0.00 | 0.0505 |     - |     - |     160 B |
|         |            |               |               |                |          |          |          |       |         |        |       |       |           |
| **IPMatch** | **Job-TYLCCQ** |      **.NET 4.8** | **192.168.2.123** |  **192.168.2.123** | **359.2 ns** | **44.25 ns** | **29.27 ns** |  **1.35** |    **0.15** | **0.0968** |     **-** |     **-** |     **305 B** |
| IPMatch | Job-YTCUUC | .NET Core 3.1 | 192.168.2.123 |  192.168.2.123 | 267.4 ns | 21.48 ns | 14.21 ns |  1.00 |    0.00 | 0.0253 |     - |     - |      80 B |