### PR TITLE
Improve performance and reduce the allocate when enforcing

### DIFF
--- a/Casbin.Benchmark/EnforcerBenchmark.cs
+++ b/Casbin.Benchmark/EnforcerBenchmark.cs
@@ -126,7 +126,7 @@ namespace Casbin.Benchmark
             NowEnforcer.EnableAutoBuildRoleLinks(false);
             for (int i = 0; i < userCount; i++)
             {
-                NowEnforcer.AddGroupingPolicy($"group{i}", $"group{i / 10}");
+                NowEnforcer.AddGroupingPolicy($"user{i}", $"group{i / 10}");
             }
             NowEnforcer.BuildRoleLinks();
 

--- a/Casbin.Benchmark/TestResource.cs
+++ b/Casbin.Benchmark/TestResource.cs
@@ -4,18 +4,12 @@
     {
         public TestResource(string name, string owner)
         {
-            this.name = name;
-            this.owner = owner;
+            Name = name;
+            Owner = owner;
         }
 
-#pragma warning disable IDE1006 // 命名样式
-        // ReSharper disable once InconsistentNaming
-        // ReSharper disable once MemberCanBePrivate.Global
-        public string name { get; set; }
+        public string Name { get; set; }
 
-        // ReSharper disable once InconsistentNaming
-        // ReSharper disable once MemberCanBePrivate.Global
-        public string owner { get; set; }
-#pragma warning restore IDE1006 // 命名样式
+        public string Owner { get; set; }
     }
 }

--- a/Casbin.Benchmark/examples/abac_model.conf
+++ b/Casbin.Benchmark/examples/abac_model.conf
@@ -8,4 +8,4 @@ p = sub, obj, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == r.obj.owner
+m = r.sub == r.obj.Owner

--- a/NetCasbin.UnitTest/ModelTest.cs
+++ b/NetCasbin.UnitTest/ModelTest.cs
@@ -270,7 +270,7 @@ namespace NetCasbin.UnitTest
         }
 
         [Fact]
-        public void TestRBACModelWithOnlyDeny()
+        public void TestRbacModelWithOnlyDeny()
         {
             var e = new Enforcer(TestModelFixture.GetNewTestModel(
                 _testModelFixture._rbacWithNotDenyModelText,

--- a/NetCasbin/Abstractions/IChainEffector.cs
+++ b/NetCasbin/Abstractions/IChainEffector.cs
@@ -1,0 +1,23 @@
+﻿using NetCasbin.Effect;
+
+namespace NetCasbin.Abstractions
+{
+    public interface IChainEffector
+    {
+        public bool Result { get; }
+
+        public bool CanChain { get; }
+
+        public string EffectExpression { get; }
+
+        public PolicyEffectType PolicyEffectType { get; }
+
+        public void StartChain(string policyEffect);
+
+        public bool Chain(Effect.Effect effect);
+
+        public bool TryChain(Effect.Effect effect);
+
+        public bool TryChain(Effect.Effect effect, out bool? result);
+    }
+}

--- a/NetCasbin/Abstractions/IExpressionHandler.cs
+++ b/NetCasbin/Abstractions/IExpressionHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using DynamicExpresso;
+
+namespace NetCasbin.Abstractions
+{
+    internal interface IExpressionHandler
+    {
+        public IDictionary<string, int> RequestTokens { get; }
+
+        public IDictionary<string, int> PolicyTokens { get; }
+
+        public IDictionary<string, Parameter> Parameters { get; } 
+
+        public void SetFunction(string name, AbstractFunction function);
+
+        public void SetGFunctions();
+
+        public void EnsureCreated(string expressionString, IReadOnlyList<object> requestValues);
+
+        public bool Invoke(string expressionString, IReadOnlyList<object> requestValues);
+
+        public void SetRequestParameters(IReadOnlyList<object> requestValues);
+
+        public void SetPolicyParameters(IReadOnlyList<string> policyValues);
+    }
+}

--- a/NetCasbin/Abstractions/IExpresstionCreator.cs
+++ b/NetCasbin/Abstractions/IExpresstionCreator.cs
@@ -4,7 +4,7 @@ using NetCasbin.Model;
 
 namespace NetCasbin.Abstractions
 {
-    public interface IExpressionProvider
+    internal interface IExpressionProvider
     {
         public Assertion RequestAssertion { get; }
 
@@ -16,6 +16,8 @@ namespace NetCasbin.Abstractions
 
         public Lambda GetExpression(string expressionString, IReadOnlyList<object> requestValues);
 
-        public IDictionary<string, Parameter> GetParameters(IReadOnlyList<object> requestValues , IReadOnlyList<string> policyValues = null);
+        public IDictionary<string, Parameter> AddOrUpdateRequestParameters(IReadOnlyList<object> requestValues);
+
+        public IDictionary<string, Parameter> AddOrUpdatePolicyParameters(IReadOnlyList<string> policyValues);
     }
 }

--- a/NetCasbin/Effect/DefaultEffector.cs
+++ b/NetCasbin/Effect/DefaultEffector.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using NetCasbin.Abstractions;
+using NetCasbin.Evaluation;
 using NetCasbin.Model;
 
 namespace NetCasbin.Effect
@@ -6,82 +10,132 @@ namespace NetCasbin.Effect
     /// <summary>
     /// DefaultEffector is default effector for Casbin.
     /// </summary>
-    public class DefaultEffector : IEffector
+    public class DefaultEffector : IEffector, IChainEffector
     {
         /// <summary>
-        ///  mergeEffects merges all matching results collected by the enforcer into a single decision.
+        /// Merges all matching results collected by the enforcer into a single decision.
         /// </summary>
-        /// <param name="expr"></param>
+        /// <param name="policyEffect"></param>
         /// <param name="effects"></param>
         /// <param name="results"></param>
         /// <returns></returns>
-        public bool MergeEffects(string expr, Effect[] effects, float[] results)
+        public bool MergeEffects(string policyEffect, Effect[] effects, float[] results)
         {
-            var result = false;
-            if (expr.Equals(PermConstants.PolicyEffect.AllowOverride))
-            {
-                foreach (var eft in effects)
-                {
-                    if (eft == Effect.Allow)
-                    {
-                        result = true;
-                        break;
-                    }
-                }
-            }
-            else if (expr.Equals(PermConstants.PolicyEffect.DenyOverride))
-            {
-                result = true;
-
-                foreach (var eft in effects)
-                {
-                    if (eft == Effect.Deny)
-                    {
-                        result = false;
-                        break;
-                    }
-                }
-            }
-            else if (expr.Equals(PermConstants.PolicyEffect.AllowAndDeny))
-            {
-                result = false;
-                foreach (var eft in effects)
-                {
-                    if (eft == Effect.Allow)
-                    {
-                        result = true;
-                    }
-                    else if (eft == Effect.Deny)
-                    {
-                        result = false;
-                        break;
-                    }
-                }
-            }
-            else if (expr.Equals(PermConstants.PolicyEffect.Priority))
-            {
-                result = false;
-                foreach (var eft in effects)
-                {
-                    if (eft != Effect.Indeterminate)
-                    {
-                        if (eft == Effect.Allow)
-                        {
-                            result = true;
-                        }
-                        else
-                        {
-                            result = false;
-                        }
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                throw new Exception("unsupported effect");
-            }
-            return result;
+            return MergeEffects(policyEffect, effects.AsSpan(), results.AsSpan());
         }
+
+
+        /// <summary>
+        /// Merges all matching results collected by the enforcer into a single decision.
+        /// </summary>
+        /// <param name="policyEffect"></param>
+        /// <param name="effects"></param>
+        /// <param name="results"></param>
+        /// <returns></returns>
+        private bool MergeEffects(string policyEffect, Span<Effect> effects, Span<float> results)
+        {
+            PolicyEffectType = ParsePolicyEffectType(policyEffect);
+            return MergeEffects(PolicyEffectType, effects, results);
+        }
+
+        /// <summary>
+        /// Merges all matching results collected by the enforcer into a single decision.
+        /// </summary>
+        /// <param name="policyEffectType"></param>
+        /// <param name="effects"></param>
+        /// <param name="results"></param>
+        /// <returns></returns>
+        private bool MergeEffects(PolicyEffectType policyEffectType, Span<Effect> effects, Span<float> results)
+        {
+            bool finalResult = false;
+            foreach (var effect in effects)
+            {
+                if (EffectEvaluator.TryEvaluate(effect, policyEffectType, ref finalResult))
+                {
+                    return finalResult;
+                }
+            }
+            return finalResult;
+        }
+
+        public static PolicyEffectType ParsePolicyEffectType(string policyEffect) => policyEffect switch
+        {
+            PermConstants.PolicyEffect.AllowOverride => PolicyEffectType.AllowOverride,
+            PermConstants.PolicyEffect.DenyOverride => PolicyEffectType.DenyOverride,
+            PermConstants.PolicyEffect.AllowAndDeny => PolicyEffectType.AllowAndDeny,
+            PermConstants.PolicyEffect.Priority => PolicyEffectType.Priority,
+            _ => throw new NotSupportedException("Not supported policy effect.")
+        };
+
+        #region IChainEffector
+
+        public bool Result { get; private set; }
+
+        public bool CanChain { get; private set; }
+
+        public string EffectExpression { get; private set; }
+
+        public PolicyEffectType PolicyEffectType { get; private set; }
+
+        public void StartChain(string effectExpression)
+        {
+            EffectExpression = effectExpression ?? throw new ArgumentNullException(nameof(effectExpression));
+            PolicyEffectType = ParsePolicyEffectType(EffectExpression);
+            CanChain = true;
+            Result = false;
+        }
+
+        public bool Chain(Effect effect)
+        {
+            if (CanChain is false)
+            {
+                throw new InvalidOperationException();
+            }
+
+            bool result = Result;
+
+            if (EffectEvaluator.TryEvaluate(effect, PolicyEffectType, ref result))
+            {
+                CanChain = false;
+                Result = result;
+                return true;
+            }
+
+            Result = result;
+            return true;
+        }
+
+        
+        public bool TryChain(Effect effect)
+        {
+            if (CanChain is false)
+            {
+                return false;
+            }
+
+            bool result = Result;
+            if (EffectEvaluator.TryEvaluate(effect, PolicyEffectType, ref result))
+            {
+                CanChain = false;
+                Result = result;
+                return true;
+            }
+
+            Result = result;
+            return true;
+        }
+
+        public bool TryChain(Effect effect, out bool? result)
+        {
+            if (TryChain(effect))
+            {
+                result = Result;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+        #endregion
     }
 }

--- a/NetCasbin/Effect/DefaultEffector.cs
+++ b/NetCasbin/Effect/DefaultEffector.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using NetCasbin.Abstractions;
 using NetCasbin.Evaluation;
 using NetCasbin.Model;
@@ -15,26 +13,26 @@ namespace NetCasbin.Effect
         /// <summary>
         /// Merges all matching results collected by the enforcer into a single decision.
         /// </summary>
-        /// <param name="policyEffect"></param>
+        /// <param name="effectExpression"></param>
         /// <param name="effects"></param>
         /// <param name="results"></param>
         /// <returns></returns>
-        public bool MergeEffects(string policyEffect, Effect[] effects, float[] results)
+        public bool MergeEffects(string effectExpression, Effect[] effects, float[] results)
         {
-            return MergeEffects(policyEffect, effects.AsSpan(), results.AsSpan());
+            return MergeEffects(effectExpression, effects.AsSpan(), results.AsSpan());
         }
 
 
         /// <summary>
         /// Merges all matching results collected by the enforcer into a single decision.
         /// </summary>
-        /// <param name="policyEffect"></param>
+        /// <param name="effectExpression"></param>
         /// <param name="effects"></param>
         /// <param name="results"></param>
         /// <returns></returns>
-        private bool MergeEffects(string policyEffect, Span<Effect> effects, Span<float> results)
+        private bool MergeEffects(string effectExpression, Span<Effect> effects, Span<float> results)
         {
-            PolicyEffectType = ParsePolicyEffectType(policyEffect);
+            PolicyEffectType = ParsePolicyEffectType(effectExpression);
             return MergeEffects(PolicyEffectType, effects, results);
         }
 
@@ -58,7 +56,7 @@ namespace NetCasbin.Effect
             return finalResult;
         }
 
-        public static PolicyEffectType ParsePolicyEffectType(string policyEffect) => policyEffect switch
+        public static PolicyEffectType ParsePolicyEffectType(string effectExpression) => effectExpression switch
         {
             PermConstants.PolicyEffect.AllowOverride => PolicyEffectType.AllowOverride,
             PermConstants.PolicyEffect.DenyOverride => PolicyEffectType.DenyOverride,

--- a/NetCasbin/Effect/Effect.cs
+++ b/NetCasbin/Effect/Effect.cs
@@ -1,7 +1,9 @@
 ﻿namespace NetCasbin.Effect
 {
-    public enum Effect
+    public enum Effect : byte
     {
-        Allow, Indeterminate, Deny
+        Allow,
+        Indeterminate,
+        Deny
     }
 }

--- a/NetCasbin/Effect/IEffector.cs
+++ b/NetCasbin/Effect/IEffector.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace NetCasbin.Effect
+﻿namespace NetCasbin.Effect
 {
     /// <summary>
     /// Effector is the interface for Casbin effectors.
@@ -10,10 +8,10 @@ namespace NetCasbin.Effect
         /// <summary>
         /// Merges all matching results collected by the enforcer into a single decision.
         /// </summary>
-        /// <param name="expr">The expression of [policy_effect].</param>
+        /// <param name="policyEffect">The expression of [policy_effect].</param>
         /// <param name="effects">The effects of all matched rules.</param>
         /// <param name="results">The matcher results of all matched rules.</param>
         /// <returns>The final effect.</returns>
-        bool MergeEffects(string expr, Effect[] effects, float[] results);
+        bool MergeEffects(string policyEffect, Effect[] effects, float[] results);
     }
 }

--- a/NetCasbin/Effect/PolicyEffectType.cs
+++ b/NetCasbin/Effect/PolicyEffectType.cs
@@ -1,0 +1,11 @@
+﻿namespace NetCasbin.Effect
+{
+    public enum PolicyEffectType
+    {
+        Custom,
+        AllowOverride,
+        AllowAndDeny,
+        DenyOverride,
+        Priority
+    }
+}

--- a/NetCasbin/Evaluation/EffiectEvaluation.cs
+++ b/NetCasbin/Evaluation/EffiectEvaluation.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using NetCasbin.Effect;
+
+namespace NetCasbin.Evaluation
+{
+    internal static class EffectEvaluator
+    {
+        internal static bool TryEvaluate(Effect.Effect effect, PolicyEffectType policyEffectType, ref bool result)
+        {
+            switch (policyEffectType)
+            {
+                case PolicyEffectType.AllowOverride:
+                {
+                    result = false;
+                    if (effect is Effect.Effect.Allow)
+                    {
+                        result = true;
+                        return true;
+                    }
+                }
+                break;
+
+                case PolicyEffectType.DenyOverride:
+                {
+                    result = true;
+                    if (effect is Effect.Effect.Deny)
+                    {
+                        result = false;
+                        return true;
+                    }
+                }
+                break;
+
+                case PolicyEffectType.AllowAndDeny:
+                    switch (effect)
+                    {
+                        case Effect.Effect.Allow:
+                            result = true;
+                            return false;
+                        case Effect.Effect.Deny:
+                            result = false;
+                            return true;
+                    }
+                    break;
+
+                case PolicyEffectType.Priority:
+                    switch (effect)
+                    {
+                        case Effect.Effect.Allow:
+                            result = true;
+                            return true;
+                        case Effect.Effect.Deny:
+                            result = false;
+                            return true;
+                    }
+                    break;
+
+                case PolicyEffectType.Custom:
+                    // TODO: Support custom policy effect.
+                    break;
+
+                default:
+                    throw new NotSupportedException("Not supported policy effect type.");
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/NetCasbin/Evaluation/ExpressionHandler.cs
+++ b/NetCasbin/Evaluation/ExpressionHandler.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DynamicExpresso;
+using NetCasbin.Abstractions;
+using NetCasbin.Model;
+using NetCasbin.Util;
+
+namespace NetCasbin.Evaluation
+{
+    public class ExpressionHandler : IExpressionHandler
+    {
+        private readonly IDictionary<string, Lambda> _expressionCache
+            = new Dictionary<string, Lambda>();
+
+        private readonly IDictionary<string, Func<string, string, string, string, string, string, bool>> _onlyStringFuncCache
+            = new Dictionary<string, Func<string, string, string, string, string, string, bool>>();
+
+        private readonly FunctionMap _functionMap = FunctionMap.LoadFunctionMap();
+        private readonly Model.Model _model;
+        private Interpreter _interpreter;
+        private readonly Parameter[] _orderedParameters;
+
+        public ExpressionHandler(Model.Model model,
+            string requestType = PermConstants.DefaultRequestType,
+            string policyType = PermConstants.DefaultPolicyType)
+        {
+            _model = model;
+            int parametersCount = 0;
+
+            if (model.Model.ContainsKey(PermConstants.Section.RequestSection))
+            {
+                RequestTokens = model.Model[PermConstants.Section.RequestSection][requestType].Tokens;
+                parametersCount += RequestTokens.Count;
+            }
+
+            if (model.Model.ContainsKey(PermConstants.Section.PolicySection))
+            {
+                PolicyTokens = model.Model[PermConstants.Section.PolicySection][policyType].Tokens;
+                parametersCount += PolicyTokens.Count;
+            }
+
+            _orderedParameters = new Parameter[parametersCount];
+        }
+
+        public IDictionary<string, int> RequestTokens { get; }
+
+        public IDictionary<string, int> PolicyTokens { get; }
+
+        public IDictionary<string, Parameter> Parameters { get; }
+            = new Dictionary<string, Parameter>();
+
+        public void SetFunction(string name, AbstractFunction function)
+        {
+            _expressionCache.Clear();
+            _onlyStringFuncCache.Clear();
+            var interpreter = GetInterpreter();
+            interpreter.SetFunction(name, function);
+        }
+
+        public void SetGFunctions()
+        {
+            _expressionCache.Clear();
+            _onlyStringFuncCache.Clear();
+            var interpreter = GetInterpreter();
+            SetGFunctions(interpreter);
+        }
+
+        
+        public void EnsureCreated(string expressionString, IReadOnlyList<object> requestValues)
+        {
+            if (_expressionCache.ContainsKey(expressionString))
+            {
+                return;
+            }
+
+            if (_onlyStringFuncCache.ContainsKey(expressionString))
+            {
+                return;
+            }
+
+            Lambda expression = CreateExpression(expressionString, requestValues);
+
+            if (RequestTokens.Count is 3 && PolicyTokens.Count is 3
+                && CheckRequestValuesOnlyString(requestValues))
+            {
+                _onlyStringFuncCache[expressionString] =
+                    expression.Compile<Func<string, string, string, string, string, string, bool>>();
+                return;
+            }
+
+            _expressionCache[expressionString] = expression;
+        }
+
+        public bool Invoke(string expressionString, IReadOnlyList<object> requestValues)
+        {
+            EnsureCreated(expressionString, requestValues);
+
+            if (_expressionCache.TryGetValue(expressionString, out var lambda))
+            {
+                var expressionResult = lambda.Invoke(_orderedParameters);
+                return expressionResult is bool result && result;
+            }
+
+            if (_onlyStringFuncCache.TryGetValue(
+                expressionString, out var func) is false)
+            {
+                throw new ArgumentException($"Can not find expression of the expression string {expressionString}");
+            }
+
+            var parameters = _orderedParameters;
+            return func(
+                parameters[0].Value as string,
+                parameters[1].Value as string,
+                parameters[2].Value as string,
+                parameters[3].Value as string,
+                parameters[4].Value as string,
+                parameters[5].Value as  string);
+        }
+
+        public void SetRequestParameters(IReadOnlyList<object> requestValues)
+        {
+            foreach (string token in RequestTokens.Keys)
+            {
+                object requestValue = requestValues?[RequestTokens[token]];
+
+                if (Parameters.ContainsKey(token))
+                {
+                    if (requestValue is not null)
+                    {
+                        Parameters[token] = new Parameter(token, requestValue);
+                    }
+                }
+                else
+                {
+                    Parameters.Add(token, new Parameter(token, requestValue ?? string.Empty));
+                }
+
+                _orderedParameters[RequestTokens[token]] = Parameters[token];
+            }
+        }
+
+        public void SetPolicyParameters(IReadOnlyList<string> policyValues = null)
+        {
+            int requestCount = RequestTokens.Count;
+            foreach (string token in PolicyTokens.Keys)
+            {
+                string policyValue = policyValues?[PolicyTokens[token]];
+
+                if (Parameters.ContainsKey(token))
+                {
+                    if (policyValue is not null)
+                    {
+                        Parameters[token] = new Parameter(token, policyValue);
+                    }
+                }
+                else
+                {
+                    Parameters.Add(token, new Parameter(token, policyValue ?? string.Empty));
+                }
+
+                _orderedParameters[PolicyTokens[token] + requestCount] = Parameters[token];
+            }
+        }
+
+        private Lambda CreateExpression(string expressionString, IReadOnlyList<object> requestValues)
+        {
+            Parameter[] parameterArray = GetParameters(requestValues);
+            Interpreter interpreter = GetInterpreter();
+            return interpreter.Parse(expressionString, parameterArray);;
+        }
+
+        private Parameter[] GetParameters(IReadOnlyList<object> requestValues = null)
+        {
+            SetRequestParameters(requestValues);
+            SetPolicyParameters();
+            return _orderedParameters;
+        }
+
+        private Interpreter GetInterpreter()
+        {
+            if (_interpreter is not null)
+            {
+                return _interpreter;
+            }
+
+            _interpreter = CreateInterpreter();
+            return _interpreter;
+        }
+
+
+        private Interpreter CreateInterpreter()
+        {
+            var interpreter = new Interpreter();
+            SetFunctions(interpreter);
+            SetGFunctions(interpreter);
+            return interpreter;
+        }
+
+        private void SetFunctions(Interpreter interpreter)
+        {
+            foreach (KeyValuePair<string, AbstractFunction> functionKeyValue in _functionMap.FunctionDict)
+            {
+                interpreter.SetFunction(functionKeyValue.Key, functionKeyValue.Value);
+            }
+        }
+
+        private void SetGFunctions(Interpreter interpreter)
+        {
+            if (_model.Model.ContainsKey(PermConstants.Section.RoleSection) is false)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<string, Assertion> assertionKeyValue in _model.Model[PermConstants.Section.RoleSection])
+            {
+                string key = assertionKeyValue.Key;
+                Assertion assertion = assertionKeyValue.Value;
+                interpreter.SetFunction(key, BuiltInFunctions.GenerateGFunction(key, assertion.RoleManager));
+            }
+        }
+
+        private bool CheckRequestValuesOnlyString(IReadOnlyCollection<object> requestValues)
+        {
+            int count = RequestTokens.Count;
+
+            if (requestValues.Count != count)
+            {
+                throw new ArgumentException("Request values count should equal to request tokens.");
+            }
+
+            return requestValues.All(value => value is string);
+        }
+    }
+}

--- a/NetCasbin/InternalEnforcer.cs
+++ b/NetCasbin/InternalEnforcer.cs
@@ -387,7 +387,7 @@ namespace NetCasbin
             if (autoBuildRoleLinks && section.Equals(PermConstants.Section.RoleSection))
             {
                 BuildRoleLinks();
-                ExpressionProvider.SetGFunctions();
+                ExpressionHandler.SetGFunctions();
             }
 
             if (autoNotifyWatcher)
@@ -401,7 +401,7 @@ namespace NetCasbin
             if (autoBuildRoleLinks && section.Equals(PermConstants.Section.RoleSection))
             {
                 BuildRoleLinks();
-                ExpressionProvider.SetGFunctions();
+                ExpressionHandler.SetGFunctions();
             }
 
             if (autoNotifyWatcher && watcher is not null)

--- a/NetCasbin/ManagementEnforcer.cs
+++ b/NetCasbin/ManagementEnforcer.cs
@@ -985,7 +985,7 @@ namespace NetCasbin
         /// <param name="function">The function.</param>
         public void AddFunction(string name, AbstractFunction function)
         {
-            ExpressionProvider.SetFunction(name, function);
+            ExpressionHandler.SetFunction(name, function);
         }
     }
 }

--- a/NetCasbin/Model/Assertion.cs
+++ b/NetCasbin/Model/Assertion.cs
@@ -18,8 +18,6 @@ namespace NetCasbin.Model
 
         public IDictionary<string, int> Tokens { set; get; }
 
-        public int TokenCount { set; get; }
-
         public IRoleManager RoleManager { get; private set; }
 
         public List<List<string>> Policy { set; get; }

--- a/NetCasbin/Model/Model.cs
+++ b/NetCasbin/Model/Model.cs
@@ -100,7 +100,6 @@ namespace NetCasbin.Model
                 if (tokens.Length != 0)
                 {
                     assertion.Tokens = new Dictionary<string, int>();
-                    assertion.TokenCount = tokens.Length;
                     for (int i = 0; i < tokens.Length; i++)
                     {
                         assertion.Tokens.Add($"{key}_{tokens[i]}", i);


### PR DESCRIPTION
close #92  and split from #90 

# Changes and Reasons
The purpose of these changes almost all is to reduce allocation.

At the old version, call the enforce method once it will allocate three arrays (matches, effects, parameters),  many repeated operations (like equal the effect expression). When RBAC It will repeat allocate enumerator at RoleManger.

These some works to resolve them:
1. for equal the effect expression, It will parse once at first and use type (enum) to pass.
2. for arrays of match and effect. Now it uses the `IChainEffector` (like the stream implement of casbin v3) to evaluate the result at every policy rule. The reason to do not use the "Stream" is this work has another semantic in .NET, it does not adapt this case. And the `IChainEffector` and `EffiectEvaluation` can gain more extendable later (like custom effect).
3. for an array of parameters. It will use `IExpressionHandler` to only update the parameters to replace allocate a new array in the old version at every call.
4. for RBAC, the role will lazy load the next level role dictionary. It means we will direct return false at HasRole when the roles do not be created. And now we will cache the GFunction result (like go casbin implement).

Every work above can reduce the allocated so it will have an obvious improvement, but it regrets that the result can not show this improvement (It has not recorded the allocated data at the old version). 

# Result
This result is not rigorous and accurate enough, because the Github Actions has a different CPU environment, but it still has a bit value to reference.

The #87 and #92 PRs have the same purpose, I use the latest commit's result before splitting the #87 PR, the link is [here](https://github.com/casbin/Casbin.NET/runs/1128890239). I use the version from the master branch as the [old version](https://github.com/casbin/Casbin.NET/runs/1104481591) and use the version from the beta branch of casbin as a [different language version](https://github.com/casbin/casbin/runs/1090977771) to compare. 

Some data looks like an abnormal data (like `RbacModelWithDeny` case) because this still uses the old version. It will update to the new version at the next mainline version (You can see this issue #94 to know more).


**Here is the result (the "-" means that this case has not recorded data):**
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.17763.1397 (1809/October2018Update/Redstone5)
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.1.402
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  Job-BFRQWF : .NET Framework 4.8 (4.8.4220.0), X64 RyuJIT
  Job-MUGNAU : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT

IterationCount=10  RunStrategy=Throughput  

```
|                     Method |       Runtime |          Mean |       Error |      StdDev | Ratio | RatioSD |    Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |-------------- |--------------:|------------:|------------:|------:|--------:|---------:|------:|------:|----------:|
|                 BasicModel (Old Version) |      .NET 4.8 |     16.981 μs |   0.2505 μs |   0.1657 μs |  1.14 |    0.02 |        - |     - |     - |         - |
|                 BasicModel (Old Version) | .NET Core 3.1 |     14.937 μs |   0.3786 μs |   0.2504 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|                 BasicModel **(Cuurrent)** |      .NET 4.8 |      2.278 μs |   0.1067 μs |   0.0705 μs |  1.00 |    0.07 |   0.0763 |     - |     - |     562 B |
|                 BasicModel **(Cuurrent)** | .NET Core 3.1 |      2.295 μs |   0.1714 μs |   0.1134 μs |  1.00 |    0.00 |   0.0191 |     - |     - |     560 B |
|              BasicModel (Other language) |       Go 1.14 |      15.583 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|                  RbacModel (Old Version) |      .NET 4.8 |     34.467 μs |   0.4745 μs |   0.2482 μs |  1.17 |    0.02 |        - |     - |     - |         - |
|                  RbacModel (Old Version) | .NET Core 3.1 |     29.584 μs |   0.8167 μs |   0.5402 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|                  RbacModel **(Cuurrent)** |      .NET 4.8 |      4.825 μs |   0.1224 μs |   0.0810 μs |  1.07 |    0.02 |   0.1907 |     - |     - |    1356 B |
|                  RbacModel **(Cuurrent)** | .NET Core 3.1 |      4.508 μs |   0.1271 μs |   0.0757 μs |  1.00 |    0.00 |   0.0458 |     - |     - |    1336 B |
|              RbacModel (Other language) |       Go 1.14 |      21.403 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|    RbacModelWithSmallScale (Old Version) |      .NET 4.8 |    865.372 μs |  28.0145 μs |  18.5298 μs |  1.12 |    0.05 |        - |     - |     - |         - |
|    RbacModelWithSmallScale (Old Version) | .NET Core 3.1 |    775.078 μs |  45.6650 μs |  30.2046 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|    RbacModelWithSmallScale **(Cuurrent)** |      .NET 4.8 |    123.378 μs |   6.1448 μs |   3.6567 μs |  1.08 |    0.06 |   5.4932 |     - |     - |   37030 B |
|    RbacModelWithSmallScale **(Cuurrent)** | .NET Core 3.1 |    114.273 μs |   4.6639 μs |   3.0849 μs |  1.00 |    0.00 |   1.3428 |     - |     - |   36912 B |
|              RbacModelWithSmallScale (Other language) |       Go 1.14 |      221.911 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|   RbacModelWithMediumScale (Old Version) |      .NET 4.8 |  8,375.131 μs | 229.1536 μs | 151.5709 μs |  1.17 |    0.03 |        - |     - |     - |         - |
|   RbacModelWithMediumScale (Old Version) | .NET Core 3.1 |  7,151.411 μs | 118.3234 μs |  78.2636 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|   RbacModelWithMediumScale **(Cuurrent)** |      .NET 4.8 |  1,151.219 μs |  45.7675 μs |  30.2724 μs |  1.03 |    0.04 |  50.7813 |     - |     - |  362743 B |
|   RbacModelWithMediumScale **(Cuurrent)** | .NET Core 3.1 |  1,120.227 μs |  42.5116 μs |  28.1188 μs |  1.00 |    0.00 |  11.7188 |     - |     - |  353720 B |
|              RbacModelWithMediumScale (Other language) |       Go 1.14 |      2,054.148 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|    RbacModelWithLargeScale (Old Version) |      .NET 4.8 | 83,915.879 μs | 2,070.1982 μs | 1,369.3080 μs |  1.18 |    0.04 |       - |     - |     - |         - |
|    RbacModelWithLargeScale (Old Version) | .NET Core 3.1 | 71,271.471 μs | 2,360.9066 μs | 1,404.9376 μs |  1.00 |    0.00 |       - |     - |     - |         - |
|    RbacModelWithLargeScale **(Cuurrent)** |      .NET 4.8 | 11,632.809 μs | 315.8767 μs | 208.9329 μs |  1.01 |    0.03 | 515.6250 |     - |     - | 3612353 B |
|    RbacModelWithLargeScale **(Cuurrent)** | .NET Core 3.1 | 11,500.617 μs | 558.5975 μs | 369.4777 μs |  1.00 |    0.00 | 125.0000 |     - |     - | 3600920 B |
|              RbacModelWithLargeScale (Other language) |       Go 1.14 |      25,304.108 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
| RbacModelWithResourceRoles (Old Version) |      .NET 4.8 |     26.034 μs |   0.7159 μs |   0.4260 μs |  1.17 |    0.03 |        - |     - |     - |         - |
| RbacModelWithResourceRoles (Old Version) | .NET Core 3.1 |     22.224 μs |   0.4023 μs |   0.2661 μs |  1.00 |    0.00 |        - |     - |     - |         - |
| RbacModelWithResourceRoles **(Cuurrent)** |      .NET 4.8 |      2.605 μs |   0.0825 μs |   0.0545 μs |  1.07 |    0.05 |   0.1030 |     - |     - |     738 B |
| RbacModelWithResourceRoles **(Cuurrent)** | .NET Core 3.1 |      2.430 μs |   0.1349 μs |   0.0892 μs |  1.00 |    0.00 |   0.0267 |     - |     - |     736 B |
|              RbacModelWithResourceRoles (Other language) |       Go 1.14 |      23.173 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|       RbacModelWithDomains (Old Version) |      .NET 4.8 |     53.576 μs |   0.9090 μs |   0.5409 μs |  1.19 |    0.02 |        - |     - |     - |         - |
|       RbacModelWithDomains (Old Version) | .NET Core 3.1 |     44.937 μs |   0.6180 μs |   0.3678 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|       RbacModelWithDomains **(Cuurrent)** |      .NET 4.8 |     13.370 μs |   0.3862 μs |   0.2298 μs |  1.24 |    0.03 |   0.5798 |     - |     - |    3964 B |
|       RbacModelWithDomains **(Cuurrent)** | .NET Core 3.1 |     10.784 μs |   0.2384 μs |   0.1577 μs |  1.00 |    0.00 |   0.1373 |     - |     - |    3944 B |
|              RbacModelWithDomains (Other language) |       Go 1.14 |      26.449 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|          RbacModelWithDeny (Old Version) |      .NET 4.8 |     46.901 μs |   0.7209 μs |   0.4769 μs |  1.15 |    0.02 |        - |     - |     - |         - |
|          RbacModelWithDeny (Old Version) | .NET Core 3.1 |     40.730 μs |   0.9919 μs |   0.6561 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|          RbacModelWithDeny **(Cuurrent)** |      .NET 4.8 |     45.144 μs |   2.1473 μs |   1.4203 μs |  1.24 |    0.08 |   2.0752 |     - |     - |   14539 B |
|          RbacModelWithDeny **(Cuurrent)** | .NET Core 3.1 |     36.543 μs |   2.6967 μs |   1.7837 μs |  1.00 |    0.00 |   0.5493 |     - |     - |   14432 B |
|              RbacModelWithDeny (Other language) |       Go 1.14 |      24.328 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|                  AbacModel (Old Version) |      .NET 4.8 |      4.976 μs |   0.1067 μs |   0.0706 μs |  1.10 |    0.03 |        - |     - |     - |         - |
|                  AbacModel (Old Version) | .NET Core 3.1 |      4.531 μs |   0.0967 μs |   0.0640 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|                  AbacModel **(Cuurrent)** |      .NET 4.8 |      4.631 μs |   0.1055 μs |   0.0698 μs |  1.26 |    0.04 |   0.2060 |     - |     - |    1492 B |
|                  AbacModel **(Cuurrent)** | .NET Core 3.1 |      3.675 μs |   0.0949 μs |   0.0628 μs |  1.00 |    0.00 |   0.0534 |     - |     - |    1480 B |
|              AbacModel (Other language) |       Go 1.14 |      7.255 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|              KeyMatchModel (Old Version) |      .NET 4.8 |     44.696 μs |   0.8131 μs |   0.4839 μs |  1.19 |    0.03 |        - |     - |     - |         - |
|              KeyMatchModel (Old Version) | .NET Core 3.1 |     37.422 μs |   1.2071 μs |   0.7984 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|              KeyMatchModel **(Cuurrent)** |      .NET 4.8 |      2.923 μs |   0.0754 μs |   0.0498 μs |  1.08 |    0.03 |   0.1755 |     - |     - |    1196 B |
|              KeyMatchModel **(Cuurrent)** | .NET Core 3.1 |      2.711 μs |   0.1114 μs |   0.0737 μs |  1.00 |    0.00 |   0.0343 |     - |     - |     968 B |
|              KeyMatchModel (Other language) |       Go 1.14 |      23.340 μs |           - |           - |    -  |       - |        - |     - |     - |         - |
|                            |               |               |             |             |       |         |          |       |       |           |
|              PriorityModel (Old Version) |      .NET 4.8 |      9.996 μs |   0.1602 μs |   0.1060 μs |  1.14 |    0.05 |        - |     - |     - |         - |
|              PriorityModel (Old Version) | .NET Core 3.1 |      8.789 μs |   0.5865 μs |   0.3879 μs |  1.00 |    0.00 |        - |     - |     - |         - |
|              PriorityModel **(Cuurrent)** |      .NET 4.8 |     10.031 μs |   0.2612 μs |   0.1366 μs |  1.22 |    0.04 |   0.4425 |     - |     - |    3145 B |
|              PriorityModel **(Cuurrent)** | .NET Core 3.1 |      8.171 μs |   0.2559 μs |   0.1693 μs |  1.00 |    0.00 |   0.1068 |     - |     - |    3128 B |
|              PriorityModel (Other language) |       Go 1.14 |      18.338 μs |           - |           - |    -  |       - |        - |     - |     - |         - |