### PR TITLE
feat: Add generic type enforce

### DIFF
--- a/NetCasbin.UnitTest/Util/TestUtil.cs
+++ b/NetCasbin.UnitTest/Util/TestUtil.cs
@@ -20,6 +20,11 @@ namespace NetCasbin.UnitTest.Util
             return values.ToList();
         }
 
+        internal static void TestEnforce<T1, T2, T3>(Enforcer e, T1 sub, T2 obj, T3 act, bool res)
+        {
+            Assert.Equal(res, e.Enforce(sub, obj, act));
+        }
+
         internal static void TestEnforce(Enforcer e, object sub, object obj, string act, bool res)
         {
             Assert.Equal(res, e.Enforce(sub, obj, act));

--- a/NetCasbin/Abstractions/IExpressionCache.cs
+++ b/NetCasbin/Abstractions/IExpressionCache.cs
@@ -1,0 +1,14 @@
+﻿namespace NetCasbin.Abstractions
+{
+    public interface IExpressionCache<T> : IExpressionCache
+    {
+        public bool TryGet(string expressionString, out T t);
+
+        public void Set(string expressionString, T t);
+    }
+
+    public interface IExpressionCache
+    {
+        public void Clear();
+    }
+}

--- a/NetCasbin/Abstractions/IExpressionHandler.cs
+++ b/NetCasbin/Abstractions/IExpressionHandler.cs
@@ -10,18 +10,21 @@ namespace NetCasbin.Abstractions
 
         public IDictionary<string, int> PolicyTokens { get; }
 
+        public IReadOnlyList<object> RequestValues { get; set; }
+
+        public IReadOnlyList<string> PolicyValues { get; set; }
+
         public IDictionary<string, Parameter> Parameters { get; } 
 
         public void SetFunction(string name, Delegate function);
 
         public void SetGFunctions();
 
-        public void EnsureCreated(string expressionString, IReadOnlyList<object> requestValues);
-
-        public bool Invoke(string expressionString, IReadOnlyList<object> requestValues);
-
-        public void SetRequestParameters(IReadOnlyList<object> requestValues);
-
-        public void SetPolicyParameters(IReadOnlyList<string> policyValues);
+        public bool Invoke(string expressionString);
+        public bool Invoke<T1>(string expressionString, T1 value1);
+        public bool Invoke<T1, T2>(string expressionString, T1 value1, T2 value2);
+        public bool Invoke<T1, T2, T3>(string expressionString, T1 value1, T2 value2, T3 value3);
+        public bool Invoke<T1, T2, T3, T4>(string expressionString, T1 value1, T2 value2, T3 value3, T4 value4);
+        public bool Invoke<T1, T2, T3, T4, T5>(string expressionString, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5);
     }
 }

--- a/NetCasbin/Caching/ReaderWriterEnforceCache.cs
+++ b/NetCasbin/Caching/ReaderWriterEnforceCache.cs
@@ -36,11 +36,6 @@ namespace NetCasbin.Caching
 
         public bool TryGetResult(IReadOnlyList<object> requestValues, string key, out bool result)
         {
-            if (requestValues is null)
-            {
-                throw new ArgumentNullException(nameof(requestValues));
-            }
-
             if (_lockSlim.TryEnterReadLock(CacheOptions.WaitTimeOut) is false)
             {
                 result = false;
@@ -65,11 +60,6 @@ namespace NetCasbin.Caching
 
         public bool TrySetResult(IReadOnlyList<object> requestValues, string key, bool result)
         {
-            if (requestValues is null)
-            {
-                throw new ArgumentNullException(nameof(requestValues));
-            }
-
             if (_lockSlim.TryEnterWriteLock(CacheOptions.WaitTimeOut) is false)
             {
                 return false;

--- a/NetCasbin/Evaluation/ExpressionCache.cs
+++ b/NetCasbin/Evaluation/ExpressionCache.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using DynamicExpresso;
+
+namespace NetCasbin.Evaluation
+{
+    public class ExpressionCache : IExpressionCache<Lambda>
+    {
+        private readonly Lazy<Dictionary<string, Lambda>> _cache = new();
+
+        public bool TryGet(string expressionString, out Lambda lambda)
+        {
+            return _cache.Value.TryGetValue(expressionString, out lambda);
+        }
+
+        public void Set(string expressionString, Lambda lambda)
+        {
+            _cache.Value[expressionString] = lambda;
+        }
+
+        public void Clear() => _cache.Value.Clear();
+    }
+
+    public class ExpressionCache<TFunc> : IExpressionCache<TFunc> where TFunc : Delegate
+    {
+        private readonly Lazy<Dictionary<string, TFunc>> _cache = new();
+
+        public bool TryGet(string expressionString, out TFunc func)
+        {
+            return _cache.Value.TryGetValue(expressionString, out func);
+        }
+
+        public void Set(string expressionString, TFunc func)
+        {
+            _cache.Value[expressionString] = func;
+        }
+
+        public void Clear() => _cache.Value.Clear();
+    }
+
+    public interface IExpressionCache<T> : IExpressionCache
+    {
+        public bool TryGet(string expressionString, out T t);
+
+        public void Set(string expressionString, T t);
+    }
+
+    public interface IExpressionCache
+    {
+        public void Clear();
+    }
+}

--- a/NetCasbin/Extensions/ExpressionHandlerExtension.cs
+++ b/NetCasbin/Extensions/ExpressionHandlerExtension.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using NetCasbin.Abstractions;
+
+namespace NetCasbin.Extensions
+{
+    internal static class ExpressionHandlerExtension
+    {
+        internal static IExpressionHandler SetRequest(this IExpressionHandler handler, params object[] requestValues)
+        {
+            handler.RequestValues = requestValues;
+            return handler;
+        }
+
+        internal static  IExpressionHandler SetRequest(this IExpressionHandler handler, IReadOnlyList<object> requestValues)
+        {
+            handler.RequestValues = requestValues;
+            return handler;
+        }
+
+        internal static IExpressionHandler SetPolicy(this IExpressionHandler handler, IReadOnlyList<string> policyValues)
+        {
+            handler.PolicyValues = policyValues;
+            return handler;
+        }
+
+        internal static bool TryGetPolicyValue(this IExpressionHandler handler, string tokenName, out string value)
+        {
+            if (handler.PolicyTokens.TryGetValue(tokenName, out int index) is false)
+            {
+                value = null;
+                return false;
+            }
+
+            value = handler.PolicyValues[index];
+            return true;
+        }
+    }
+}

--- a/NetCasbin/Extensions/LoggerExtension.cs
+++ b/NetCasbin/Extensions/LoggerExtension.cs
@@ -7,6 +7,26 @@ namespace NetCasbin.Extensions
 {
     public static class LoggerExtension
     {
+        public static void LogEnforceCachedResult<T1, T2, T3>(this ILogger logger, T1 value1, T2 value2, T3 value3, bool result)
+        {
+            logger.LogInformation("Request: {1}, {2}, {3} ---> {0} (cached)", result, value1, value2, value3);
+        }
+
+        public static void LogEnforceResult<T1, T2, T3>(this ILogger logger, T1 value1, T2 value2, T3 value3, bool result)
+        {
+            logger.LogInformation("Request: {1}, {2}, {3} ---> {0}", result, 
+                string.Join(", ", value1, value2, value3));
+        }
+
+        public static void LogEnforceResult<T1, T2, T3>(this ILogger logger, T1 value1, T2 value2, T3 value3,
+            bool result, IEnumerable<IEnumerable<string>> explains)
+        {
+            logger.LogInformation("Request: {1}, {2}, {3} ---> {0}\nHit Policy: {4}", result, 
+                value1, value2, value3,
+                string.Join("\n", explains.Select(explain =>
+                    string.Join(", ", explain))));
+        }
+
         public static void LogEnforceCachedResult(this ILogger logger, IEnumerable<object> requestValues, bool result)
         {
             logger.LogInformation("Request: {1} ---> {0} (cached)", result, 


### PR DESCRIPTION
for https://github.com/casbin/Casbin.NET/issues/94 and https://github.com/casbin/Casbin.NET/issues/108

**Draft:** Now, this feature only implements for test and benchmark cases (**except RbacModelWithDomains**).



## Performance Improvement

This feature can bring amazing performance improvements.

**Here is the result (the "-" means that this case has not recorded data):**

**Data Source:**

- Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04) : https://github.com/casbin/Casbin.NET/runs/2268814642

- Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) : https://github.com/casbin/Casbin.NET/runs/2261333797
- Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) : https://github.com/casbin/casbin/runs/2258292320
- Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) : https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a#commitcomment-46566627

**Cabin.NET Environment:**

``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.17763.1817 (1809/October2018Update/Redstone5)
Intel Xeon Platinum 8171M CPU 2.60GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  Job-FHENMY : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
  Job-XXLEZF : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  Job-BYYCSW : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
```

**Result:**

| Method                     | Version                                                      | Runtime              |          Mean | Allocated |
| -------------------------- | ------------------------------------------------------------ | -------------------- | ------------: | --------: |
| BasicModel                 | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | NET 5                |      0.520 μs |      48 B |
| BasicModel                 | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      0.610 μs |      48 B |
| BasicModel                 | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      2.408 μs |     560 B |
| BasicModel                 | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |      2.687 μs |     560 B |
| BasicModel                 | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     14.865 μs |         - |
| BasicModel                 | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |      9.197 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModel                  | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      1.154 μs |     312 B |
| RbacMode                   | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      1.338 μs |     312 B |
| RbacMode                   | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      4.943 μs |    1336 B |
| RbacModel                  | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |      5.520 μs |    1336 B |
| RbacModel                  | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     20.705 μs |         - |
| RbacModel                  | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |     15.793 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithSmallScale    | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |     28.148 μs |   10032 B |
| RbacModelWithSmallScale    | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |     31.273 μs |   10032 B |
| RbacModelWithSmallScale    | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |    124.265 μs |   36912 B |
| RbacModelWithSmallScale    | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |    133.864 μs |   36912 B |
| RbacModelWithSmallScale    | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |    158.815 μs |         - |
| RbacModelWithSmallScale    | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |    170.763 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithMediumScale   | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |    276.773 μs |   96440 B |
| RbacModelWithMediumScale   | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |    303.227 μs |   96440 B |
| RbacModelWithMediumScale   | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |  1,215.587 μs |  353721 B |
| RbacModelWithMediumScale   | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |  1,324.172 μs |  353721 B |
| RbacModelWithMediumScale   | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |  1,598.352 μs |         - |
| RbacModelWithMediumScale   | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |  1,735.200 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithLargeScale    | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |  2,964.988 μs | 1039640 B |
| RbacModelWithLargeScale    | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |  3,227.230 μs | 1039640 B |
| RbacModelWithLargeScale    | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               | 12,205.747 μs | 3600921 B |
| RbacModelWithLargeScale    | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        | 13,711.985 μs | 3600920 B |
| RbacModelWithLargeScale    | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              | 18,861.133 μs |         - |
| RbacModelWithLargeScale    | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly | 17,890.592 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithResourceRoles | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      0.721 μs |     224 B |
| RbacModelWithResourceRoles | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      0.833 μs |     224 B |
| RbacModelWithResourceRoles | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      2.614 μs |     736 B |
| RbacModelWithResourceRoles | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |      2.973 μs |     736 B |
| RbacModelWithResourceRoles | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     23.263 μs |         - |
| RbacModelWithResourceRoles | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |     13.763 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithDomains       | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |     13.325 μs |    3808 B |
| RbacModelWithDomains       | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |     13.785 μs |    3944 B |
| RbacModelWithDomains       | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |     13.431 μs |    3808 B |
| RbacModelWithDomains       | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |     13.549 μs |    3944 B |
| RbacModelWithDomains       | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     29.879 μs |         - |
| RbacModelWithDomains       | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |     17.226 μs |         - |
|                            |                                                              |                      |               |           |
| RbacModelWithDeny          | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      1.766 μs |     496 B |
| RbacModelWithDeny          | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      1.985 μs |     496 B |
| RbacModelWithDeny          | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |     44.324 μs |   13752 B |
| RbacModelWithDeny          | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |     46.901 μs |   14432 B |
| RbacModelWithDeny          | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     21.655 μs |         - |
| RbacModelWithDeny          | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |     19.023 μs |         - |
|                            |                                                              |                      |               |           |
| AbacModel                  | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      0.504 μs |     136 B |
| AbacModel                  | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      0.578 μs |     136 B |
| AbacModel                  | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      5.726 μs |    1688 B |
| AbacModel                  | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |      6.204 μs |    1824 B |
| AbacModel                  | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |      7.339 μs |         - |
| AbacModel                  | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |      7.171 μs |         - |
|                            |                                                              |                      |               |           |
| KeyMatchModel              | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      0.907 μs |     352 B |
| KeyMatchModel              | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      1.107 μs |     456 B |
| KeyMatchModel              | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      2.892 μs |     864 B |
| KeyMatchModel              | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |      3.130 μs |    1196 B |
| KeyMatchModel              | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     25.722 μs |         - |
| KeyMatchModel              | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |    39..817 μs |         - |
|                            |                                                              |                      |               |           |
| PriorityModel              | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET 5               |      0.678 μs |     136 B |
| PriorityModel              | **Current [fc72472](https://github.com/casbin/Casbin.NET/commit/fc724720b50820b470c7f9c268b923a1aa541d04)** | .NET Core 3.1        |      0.766 μs |     136 B |
| PriorityModel              | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET 5               |      9.759 μs |    2992 B |
| PriorityModel              | Old [670cb83](https://github.com/casbin/Casbin.NET/commit/670cb838594ff12bb6413d88f47835ac2866385c) | .NET Core 3.1        |     10.563 μs |    3128 B |
| PriorityModel              | Golang [3040d51](https://github.com/casbin/casbin/commit/3040d51f0f5157c503db68c8c24c23afa220f1d3) | Go 1.14              |     18.338 μs |         - |
| PriorityModel              | Rust [1be8610](https://github.com/casbin/casbin-rs/commit/1be861034d4b265b5f8274567499e9c24fc92e5a) | rustc 1.51.0-nightly |     13.009 μs |         - |

