### PR TITLE
Added new PolicyEffectType.Deny

### DIFF
--- a/NetCasbin/Effect/DefaultEffector.cs
+++ b/NetCasbin/Effect/DefaultEffector.cs
@@ -72,6 +72,7 @@ namespace NetCasbin.Effect
             PermConstants.PolicyEffect.DenyOverride => PolicyEffectType.DenyOverride,
             PermConstants.PolicyEffect.AllowAndDeny => PolicyEffectType.AllowAndDeny,
             PermConstants.PolicyEffect.Priority => PolicyEffectType.Priority,
+            PermConstants.PolicyEffect.Deny => PolicyEffectType.Deny,
             _ => throw new NotSupportedException("Not supported policy effect.")
         };
 

--- a/NetCasbin/Effect/PolicyEffectType.cs
+++ b/NetCasbin/Effect/PolicyEffectType.cs
@@ -6,6 +6,7 @@
         AllowOverride,
         AllowAndDeny,
         DenyOverride,
-        Priority
+        Priority,
+        Deny
     }
 }

--- a/NetCasbin/Evaluation/EffiectEvaluation.cs
+++ b/NetCasbin/Evaluation/EffiectEvaluation.cs
@@ -64,6 +64,20 @@ namespace NetCasbin.Evaluation
                     }
                     break;
 
+                case PolicyEffectType.Deny:
+                    {
+                        result = false;
+                        if (effect is Effect.Effect.Deny)
+                        {
+                            result = true;
+                            hitPolicy = true;
+                            return true;
+                        }
+                    }
+                    break;
+
+
+
                 case PolicyEffectType.Custom:
                     // TODO: Support custom policy effect.
                     break;

--- a/NetCasbin/Model/PermConstants.cs
+++ b/NetCasbin/Model/PermConstants.cs
@@ -53,6 +53,8 @@
             public const string DenyOverride = "!some(where (p_eft == deny))";
             public const string AllowAndDeny = "some(where (p_eft == allow)) && !some(where (p_eft == deny))";
             public const string Priority = "priority(p_eft) || deny";
+            public const string Deny = "some(where (p_eft == deny))";
+
         }
     }
 }


### PR DESCRIPTION
I don't think you will accept this PR, but I want to tell you why I needed the **PolicyEffectType.Deny** effect.

We are developing a no-code, low-code CRM system. In it, the user can create entities using the UI without programming, based on this metadata, tables in the database and links between them are created.
In this solution, we decided to use Casbin as the basis for building an access control mechanism.
Access control is carried out both at the level of access to the entity and at the level of access to the elements of the entity. Those. policies are created both for accessing the table and for individual records in the table. Well, plus the entity can still have different states, and this is also taken into account in the policies.

And the access policies that are assigned at the entity (table) level are stored in one table, and the access policies for entity elements (table records) are stored in another table, but they are all stored in the Casbin format (**_ICasbinRule_**). Moreover, "**eft**" can be either "**allow**" or "**deny**". "**Deny**" takes precedence and overrides "**allow**".

And accordingly, when I need to get an authorization response, I have to check both the table with the policies at the entity level and the table of permissions at the entity element level. Moreover, access policies at the level of entity elements override the access policies set at the entity level.

In this situation, I can solve this problem if I do a multi-step check.
First, I have to load the filtered policies into all Enforcer. For policies set at the entity level, I have to load by the ID of that entity. And for policies at the entity element level, I have to load the policies filtered by the entity element ID.

And first, I have to check the policies set at the entity element level, if there are prohibiting policies for this operation, if any, then access is denied. And for that I modified Casbin and added the "Deny" effect (PolicyEffectType.Deny).
Next I have to check if there is a permissive policy (PolicyEffectType.AllowOverride effect). And there is, so there is no need to check further, since permissions at the entity element level override the permission set at the entity level. And that means there is access.

And only after it receives an answer that there are no permissive policies, only then it will be possible to check the policies set at the entity level in order to receive a response from the Enforcer with the effect (DenyOverride).

Here is such a non-standard use of the Casbin library and this approach to authorization. But thanks to the flexibility of Casbin and the PERM approach, I can build such complex authorization scripts.