### PR TITLE
feat: Support priority deny override model

### DIFF
--- a/NetCasbin.UnitTest/Fixtures/TestModelFixture.cs
+++ b/NetCasbin.UnitTest/Fixtures/TestModelFixture.cs
@@ -19,6 +19,8 @@ namespace NetCasbin.UnitTest.Fixtures
         internal readonly string _keyMatchCustomModelText = ReadTestFile("keymatch_custom_model.conf");
         internal readonly string _priorityModelText = ReadTestFile("priority_model.conf");
         internal readonly string _priorityExplicitModelText = ReadTestFile("priority_explicit_model.conf");
+        internal readonly string _priorityExplicitDenyOverrideModelText = ReadTestFile("priority_explicit_deny_override_model.conf");
+
         internal readonly string _rbacModelText = ReadTestFile("rbac_model.conf");
         internal readonly string _rbacWithDenyModelText = ReadTestFile("rbac_with_deny_model.conf");
         internal readonly string _rbacWithNotDenyModelText = ReadTestFile("rbac_with_not_deny_model.conf");
@@ -34,6 +36,7 @@ namespace NetCasbin.UnitTest.Fixtures
         internal readonly string _keyMatch2PolicyText = ReadTestFile("keymatch2_policy.csv");
         internal readonly string _priorityPolicyText = ReadTestFile("priority_policy.csv");
         internal readonly string _priorityExplicitPolicyText = ReadTestFile("priority_explicit_policy.csv");
+        internal readonly string _priorityExplicitDenyOverridePolicyText = ReadTestFile("priority_explicit_deny_override_policy.csv");
         internal readonly string _priorityIndeterminatePolicyText = ReadTestFile("priority_indeterminate_policy.csv");
         internal readonly string _rbacPolicyText = ReadTestFile("rbac_policy.csv");
         internal readonly string _rbacWithDenyPolicyText = ReadTestFile("rbac_with_deny_policy.csv");
@@ -97,6 +100,11 @@ namespace NetCasbin.UnitTest.Fixtures
             return GetNewTestModel(_priorityExplicitModelText, _priorityExplicitPolicyText);
         }
 
+        public Model.Model GetNewPriorityExplicitDenyOverrideModel()
+        {
+            return GetNewTestModel(_priorityExplicitDenyOverrideModelText, _priorityExplicitDenyOverridePolicyText);
+        }
+        
         public Model.Model GetNewRbacTestModel()
         {
             return GetNewTestModel(_rbacModelText, _rbacPolicyText);

--- a/NetCasbin.UnitTest/ModelTest.cs
+++ b/NetCasbin.UnitTest/ModelTest.cs
@@ -495,6 +495,31 @@ namespace NetCasbin.UnitTest
         }
 
         [Fact]
+        public void TestPriorityExplicitDenyOverrideModel()
+        {
+            var e = new Enforcer(_testModelFixture.GetNewPriorityExplicitDenyOverrideModel());
+            e.BuildRoleLinks();
+
+            TestEnforce(e, "alice", "data2", "write", true);
+            TestEnforce(e, "bob", "data2", "read", true);
+
+            //adding a new group, simulating behaviour when two different groups are added to the same person
+            e.AddPolicy("10", "data2_deny_group_new", "data2", "write", "deny");
+            e.AddGroupingPolicy("alice", "data2_deny_group_new");
+
+            TestEnforce(e, "alice", "data2", "write", false);
+            TestEnforce(e, "bob", "data2", "read", true);
+
+            //adding higher priority policy for alice, to override group policies
+            e.AddPolicy("1", "alice", "data2", "write", "allow");
+            TestEnforce(e, "alice", "data2", "write", true);
+
+            //adding deny policy for alice for the same obj, to ensure that if there is at least one deny, final result will be deny
+            e.AddPolicy("1", "alice", "data2", "write", "deny");
+            TestEnforce(e, "alice", "data2", "write", false);
+        }
+
+        [Fact]
         public void TestKeyMatch2Model()
         {
             var e = new Enforcer(_testModelFixture.GetNewKeyMatch2TestModel());

--- a/NetCasbin.UnitTest/NetCasbin.UnitTest.csproj
+++ b/NetCasbin.UnitTest/NetCasbin.UnitTest.csproj
@@ -88,7 +88,13 @@
     <None Update="examples\keymatch_policy.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="examples\priority_explicit_deny_override_model.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="examples\priority_explicit_model.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\priority_explicit_deny_override_policy.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="examples\priority_explicit_policy.csv">

--- a/NetCasbin.UnitTest/Util/TestUtil.cs
+++ b/NetCasbin.UnitTest/Util/TestUtil.cs
@@ -22,8 +22,6 @@ namespace NetCasbin.UnitTest.Util
 
         internal static void TestEnforce(Enforcer e, object sub, object obj, string act, bool res)
         {
-            var explains = e.EnforceEx(sub, obj, act);
-
             Assert.Equal(res, e.Enforce(sub, obj, act));
         }
 

--- a/NetCasbin.UnitTest/Util/TestUtil.cs
+++ b/NetCasbin.UnitTest/Util/TestUtil.cs
@@ -22,6 +22,8 @@ namespace NetCasbin.UnitTest.Util
 
         internal static void TestEnforce(Enforcer e, object sub, object obj, string act, bool res)
         {
+            var explains = e.EnforceEx(sub, obj, act);
+
             Assert.Equal(res, e.Enforce(sub, obj, act));
         }
 

--- a/NetCasbin.UnitTest/examples/priority_explicit_deny_override_model.conf
+++ b/NetCasbin.UnitTest/examples/priority_explicit_deny_override_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = priority, sub, obj, act, eft
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = priority(p_eft) && !some(where (p_eft == deny))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/NetCasbin.UnitTest/examples/priority_explicit_deny_override_policy.csv
+++ b/NetCasbin.UnitTest/examples/priority_explicit_deny_override_policy.csv
@@ -1,0 +1,10 @@
+p, 10, data1_deny_group, data1, read, deny
+p, 10, data1_deny_group, data1, write, deny
+
+p, 10, data2_allow_group, data2, read, allow
+p, 10, data2_allow_group, data2, write, allow
+
+
+g, bob, data2_allow_group
+g, alice, data2_allow_group
+

--- a/NetCasbin/Effect/DefaultEffector.cs
+++ b/NetCasbin/Effect/DefaultEffector.cs
@@ -72,6 +72,7 @@ namespace NetCasbin.Effect
             PermConstants.PolicyEffect.DenyOverride => PolicyEffectType.DenyOverride,
             PermConstants.PolicyEffect.AllowAndDeny => PolicyEffectType.AllowAndDeny,
             PermConstants.PolicyEffect.Priority => PolicyEffectType.Priority,
+            PermConstants.PolicyEffect.PriorityDenyOverride => PolicyEffectType.PriorityDenyOverride,
             _ => throw new NotSupportedException("Not supported policy effect.")
         };
 

--- a/NetCasbin/Effect/PolicyEffectType.cs
+++ b/NetCasbin/Effect/PolicyEffectType.cs
@@ -6,6 +6,7 @@
         AllowOverride,
         AllowAndDeny,
         DenyOverride,
-        Priority
+        Priority,
+        PriorityDenyOverride
     }
 }

--- a/NetCasbin/Evaluation/EffiectEvaluation.cs
+++ b/NetCasbin/Evaluation/EffiectEvaluation.cs
@@ -64,6 +64,20 @@ namespace NetCasbin.Evaluation
                     }
                     break;
 
+                case PolicyEffectType.PriorityDenyOverride:
+                    switch (effect)
+                    {
+                        case Effect.Effect.Allow:
+                            result = true;
+                            hitPolicy = true;
+                            return false; 
+                        case Effect.Effect.Deny:
+                            result = false;
+                            hitPolicy = true;
+                            return true;
+                    }
+                    break;
+
                 case PolicyEffectType.Custom:
                     // TODO: Support custom policy effect.
                     break;

--- a/NetCasbin/Model/PermConstants.cs
+++ b/NetCasbin/Model/PermConstants.cs
@@ -53,6 +53,7 @@
             public const string DenyOverride = "!some(where (p_eft == deny))";
             public const string AllowAndDeny = "some(where (p_eft == allow)) && !some(where (p_eft == deny))";
             public const string Priority = "priority(p_eft) || deny";
+            public const string PriorityDenyOverride = "priority(p_eft) && !some(where (p_eft == deny))";
         }
     }
 }


### PR DESCRIPTION
This PR adds support for a new PolicyEffect - PriorityDenyOverride.
It allows having multiple groups with explicit priority rank to be assigned to the same entity.

Please refer to https://github.com/casbin/Casbin.NET/issues/188 for the details and detailed issue description.