### PR TITLE
perf: resolve issue when for priority-deny-override mode, all policies were scanned, even if effect was found on higher priority levels

### DIFF
--- a/NetCasbin/Abstractions/IChainEffector.cs
+++ b/NetCasbin/Abstractions/IChainEffector.cs
@@ -10,6 +10,8 @@ namespace NetCasbin.Abstractions
 
         public bool HitPolicy { get; }
 
+        public int HitPolicyCount { get; }
+
         public string EffectExpression { get; }
 
         public PolicyEffectType PolicyEffectType { get; }

--- a/NetCasbin/CoreEnforcer.cs
+++ b/NetCasbin/CoreEnforcer.cs
@@ -984,7 +984,7 @@ namespace NetCasbin
                         if (int.TryParse(policyValues[priorityIndex], out int nowPriority))
                         {
                             if (priority.HasValue && nowPriority != priority.Value
-                                && nowEffect is not Effect.Effect.Indeterminate)
+                                && chainEffector.HitPolicyCount > 0)
                             {
                                 break;
                             }

--- a/NetCasbin/Effect/DefaultEffector.cs
+++ b/NetCasbin/Effect/DefaultEffector.cs
@@ -82,6 +82,8 @@ namespace NetCasbin.Effect
 
         public bool HitPolicy { get; private set; }
 
+        public int HitPolicyCount { get; private set; }
+
         public bool CanChain { get; private set; }
 
         public string EffectExpression { get; private set; }
@@ -94,6 +96,7 @@ namespace NetCasbin.Effect
             PolicyEffectType = ParsePolicyEffectType(EffectExpression);
             CanChain = true;
             Result = false;
+            HitPolicyCount = 0;
         }
 
         public bool Chain(Effect effect)
@@ -111,11 +114,13 @@ namespace NetCasbin.Effect
                 CanChain = false;
                 Result = result;
                 HitPolicy = hitPolicy;
+                HitPolicyCount = hitPolicy ? ++HitPolicyCount : HitPolicyCount;
                 return true;
             }
 
             Result = result;
             HitPolicy = hitPolicy;
+            HitPolicyCount = hitPolicy ? ++HitPolicyCount : HitPolicyCount;
             return true;
         }
 
@@ -134,11 +139,13 @@ namespace NetCasbin.Effect
                 CanChain = false;
                 Result = result;
                 HitPolicy = hitPolicy;
+                HitPolicyCount = hitPolicy ? ++HitPolicyCount : HitPolicyCount;
                 return true;
             }
 
             Result = result;
             HitPolicy = hitPolicy;
+            HitPolicyCount = hitPolicy ? ++HitPolicyCount : HitPolicyCount;
             return true;
         }
 


### PR DESCRIPTION
I've noticed that performance is very poor for policy files containing 10k+ policies, even when trying to enforce highest priority level policies.

It turned out, that we cannot rely on **nowEffect is not Effect.Effect.Indeterminate** check, as in some policy file versions it will never recover from **Indeterminate** status.

Easiest way how to reproduce a performance issue I'm talking about is:
**1. to replace policies of priority_explicit_deny_override_policy.csv**

```csv
p, 1, my_sub,my_obj,my_act_read,allow
p, 1, my_sub,my_obj,my_act_write,allow
p, 2, my_sub2,my_obj2,my_act_read2,allow
p, 2, my_sub2,my_obj2,my_act_write2,allow

g, alice, my_sub
```

**2. Add following test**

```c#
        public void TestPriorityExplicitDenyOverrideModel()
        {
            var e = new Enforcer(_testModelFixture.GetNewPriorityExplicitDenyOverrideModel());
            e.BuildRoleLinks();
            TestEnforce(e, "alice", "my_obj", "my_act_read", true);
        }
```

3. Run the test in debug mode and notice, that CoreEnforcer went thru all 4 policies, but should break after scanning first two
For 10k policies cases, it most likely will go thru each of them. 


My proposing change is to add a hit policies counter to chainEffector, and checking against hit policies count while jumping to lower priority level.