### PR TITLE
feat: Add keymatch5 for ignoring params in url

### DIFF
--- a/Casbin.UnitTest/UtilTests/BuiltInFunctionTest.cs
+++ b/Casbin.UnitTest/UtilTests/BuiltInFunctionTest.cs
@@ -172,6 +172,24 @@ namespace Casbin.UnitTests.UtilTests
                 BuiltInFunctions.KeyMatch4(key1, key2));
         }
 
+        public static IEnumerable<object[]> KeyMatch5TestData = new[]
+        {
+            new object[] { "/parent/child?status=1&type=2", "/parent/child", true},
+            new object[] { "/parent?status=1&type=2", "/parent/child", false},
+
+            new object[] { "/parent/child/?status=1&type=2", "/parent/child/", true},
+            new object[] { "/parent/child/?status=1&type=2", "/parent/child", false},
+            new object[] { "/parent/child?status=1&type=2", "/parent/child/", false}
+        };
+
+        [Theory]
+        [MemberData(nameof(KeyMatch5TestData))]
+        public void TestKeyMatch5(string key1, string key2, bool expectedResult)
+        {
+            Assert.Equal(expectedResult,
+                BuiltInFunctions.KeyMatch5(key1, key2));
+        }
+
         public static IEnumerable<object[]> GlobMatchTestData = new[]
         {
             new object[] {"/foo", "/foo", true},

--- a/Casbin/Model/FunctionMap.cs
+++ b/Casbin/Model/FunctionMap.cs
@@ -24,6 +24,7 @@ namespace Casbin.Model
             map.AddFunction("keyMatch2", BuiltInFunctions.KeyMatch2);
             map.AddFunction("keyMatch3", BuiltInFunctions.KeyMatch3);
             map.AddFunction("keyMatch4", BuiltInFunctions.KeyMatch4);
+            map.AddFunction("keyMatch5", BuiltInFunctions.KeyMatch5);
             map.AddFunction("regexMatch", BuiltInFunctions.RegexMatch);
             map.AddFunction("ipMatch", BuiltInFunctions.IPMatch);
             map.AddFunction("globMatch", BuiltInFunctions.GlobMatch);

--- a/Casbin/Util/BuiltInFunctions.cs
+++ b/Casbin/Util/BuiltInFunctions.cs
@@ -128,6 +128,22 @@ namespace Casbin.Util
 
             return true;
         }
+        /// <summary>
+        /// KeyMatch determines whether key1 matches the pattern of key2 and ignores the parameters in key2.
+        /// For example, "/foo/bar?status=1&amp;type=2" matches "/foo/bar"
+        /// </summary>
+        /// <param name="key1"> The first argument. </param>
+        /// <param name="key2"> The second argument. </param>
+        /// <returns></returns>
+        public static bool KeyMatch5(string key1, string key2)
+        {
+            var key1Span = key1.AsSpan();
+            var key2Span = key2.AsSpan();
+            int index = key1Span.IndexOf('?');
+            return index is -1
+                ? key1Span.Equals(key2Span, StringComparison.Ordinal)
+                : key1Span.Slice(0, index).Equals(key2Span, StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Determines whether IP address ip1 matches the pattern of IP address ip2,


### PR DESCRIPTION
Fix: #255 

### What problem does this PR solve?
Add KeyMatch5 to ignoring params in URL when matching keys.

Related Issue: #255 

### What is changed and how it works?
Add a new operation keyMatch5
