### PR TITLE
feat: Add UpdatePolicy and UpdatePolicies APIs

### DIFF
--- a/Casbin.UnitTest/ModelTests/ManagementApiTest.cs
+++ b/Casbin.UnitTest/ModelTests/ManagementApiTest.cs
@@ -122,6 +122,68 @@ namespace Casbin.UnitTests.ModelTests
 
             e.RemoveFilteredPolicy(1, "");
             TestGetPolicy(e, AsList(AsList("eve", "data3", "read")));
+
+            bool res = e.UpdatePolicy(AsList("eve", "data3", "read"), AsList("eve", "data3", "write"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy will not be updated.
+            res = e.UpdatePolicy(AsList("non_exist", "data3", "write"), AsList("non_exist", "data3", "read"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.False(res);
+
+            e.AddPolicies(rules);
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "write"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data4", "write"),
+                AsList("leyo", "data4", "read"),
+                AsList("ham", "data4", "write")));
+
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "write"),
+                    AsList("leyo", "data4", "read"),
+                    AsList("katy", "data4", "write")),
+                AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("katy", "data1", "write")));
+            TestGetPolicy(e, AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("jack", "data4", "read"),
+                    AsList("katy", "data1", "write"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("ham", "data4", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy in oldParameters will not be updated, so other existent ones
+            // will be ignored and the return value will be False.
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("non_exist", "data4", "read")),
+                AsList(
+                    AsList("eve", "data3", "write"), AsList("non_exist", "data4", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("leyo", "data4", "write")),
+                AsList(AsList("eve", "data3", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
         }
 
         [Fact]
@@ -141,7 +203,7 @@ namespace Casbin.UnitTests.ModelTests
             await e.RemovePolicyAsync("alice", "data1", "read");
             await e.AddPolicyAsync("eve", "data3", "read");
             await e.AddPolicyAsync("eve", "data3", "read");
-            
+
             var rules = AsList(
                 AsList("jack", "data4", "read"),
                 AsList("jack", "data4", "read"),
@@ -182,6 +244,68 @@ namespace Casbin.UnitTests.ModelTests
             await e.RemoveFilteredPolicyAsync(1, "data2");
 
             TestGetPolicy(e, AsList(AsList("eve", "data3", "read")));
+
+            bool res = await e.UpdatePolicyAsync(AsList("eve", "data3", "read"), AsList("eve", "data3", "write"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy will not be updated.
+            res = await e.UpdatePolicyAsync(AsList("non_exist", "data3", "write"), AsList("non_exist", "data3", "read"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.False(res);
+
+            await e.AddPoliciesAsync(rules);
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "write"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data4", "write"),
+                AsList("leyo", "data4", "read"),
+                AsList("ham", "data4", "write")));
+
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "write"),
+                    AsList("leyo", "data4", "read"),
+                    AsList("katy", "data4", "write")),
+                AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("katy", "data1", "write")));
+            TestGetPolicy(e, AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("jack", "data4", "read"),
+                    AsList("katy", "data1", "write"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("ham", "data4", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy in oldParameters will not be updated, so other existent ones
+            // will be ignored and the return value will be False.
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("non_exist", "data4", "read")),
+                AsList(
+                    AsList("eve", "data3", "write"), AsList("non_exist", "data4", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("leyo", "data4", "write")),
+                AsList(AsList("eve", "data3", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
         }
 
         [Fact]
@@ -236,6 +360,58 @@ namespace Casbin.UnitTests.ModelTests
             TestGetUsers(e, "data1_admin", AsList());
             TestGetUsers(e, "data2_admin", AsList());
             TestGetUsers(e, "data3_admin", AsList("eve"));
+
+            e.AddGroupingPolicy("data3_admin", "data4_admin");
+            bool res = e.UpdateGroupingPolicy(AsList("eve", "data3_admin"), AsList("eve", "admin"));
+            Assert.True(res);
+            res = e.UpdateGroupingPolicy(AsList("data3_admin", "data4_admin"), AsList("admin", "data4_admin"));
+            Assert.True(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+            TestGetUsers(e, "admin", AsList("eve"));
+            TestGetRoles(e, "eve", AsList("admin"));
+            TestGetRoles(e, "admin", AsList("data4_admin"));
+
+            res = e.UpdateGroupingPolicy(AsList("non_exist", "data4_admin"), AsList("non_exist2", "data4_admin"));
+            Assert.False(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("eve", "admin"),
+                    AsList("admin", "data4_admin")),
+                AsList(
+                    AsList("eve", "admin_groups"),
+                    AsList("admin", "data5_admin")));
+
+            Assert.True(res);
+            TestGetUsers(e, "data5_admin", AsList("admin"));
+            TestGetUsers(e, "admin_groups", AsList("eve"));
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("non_exist", "admin_groups")
+                    ),
+                AsList(
+                    AsList("admin", "data6_admin"),
+                    AsList("non_exist2", "admin_groups")
+                    ));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("eve", "admin2_groups")),
+                AsList(
+                    AsList("admin", "data6_admin")));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
         }
 
         [Fact]
@@ -289,6 +465,58 @@ namespace Casbin.UnitTests.ModelTests
             TestGetUsers(e, "data1_admin", AsList());
             TestGetUsers(e, "data2_admin", AsList());
             TestGetUsers(e, "data3_admin", AsList("eve"));
+
+            await e.AddGroupingPolicyAsync("data3_admin", "data4_admin");
+            bool res = await e.UpdateGroupingPolicyAsync(AsList("eve", "data3_admin"), AsList("eve", "admin"));
+            Assert.True(res);
+            res = await e.UpdateGroupingPolicyAsync(AsList("data3_admin", "data4_admin"), AsList("admin", "data4_admin"));
+            Assert.True(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+            TestGetUsers(e, "admin", AsList("eve"));
+            TestGetRoles(e, "eve", AsList("admin"));
+            TestGetRoles(e, "admin", AsList("data4_admin"));
+
+            res = await e.UpdateGroupingPolicyAsync(AsList("non_exist", "data4_admin"), AsList("non_exist2", "data4_admin"));
+            Assert.False(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("eve", "admin"),
+                    AsList("admin", "data4_admin")),
+                AsList(
+                    AsList("eve", "admin_groups"),
+                    AsList("admin", "data5_admin")));
+
+            Assert.True(res);
+            TestGetUsers(e, "data5_admin", AsList("admin"));
+            TestGetUsers(e, "admin_groups", AsList("eve"));
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("non_exist", "admin_groups")
+                    ),
+                AsList(
+                    AsList("admin", "data6_admin"),
+                    AsList("non_exist2", "admin_groups")
+                    ));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("eve", "admin2_groups")),
+                AsList(
+                    AsList("admin", "data6_admin")));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
         }
     }
 }

--- a/Casbin.UnitTest/SyncedModelTests/SyncedManagementApiTest.cs
+++ b/Casbin.UnitTest/SyncedModelTests/SyncedManagementApiTest.cs
@@ -122,6 +122,68 @@ namespace Casbin.UnitTests.SyncedModelTests
 
             e.RemoveFilteredPolicy(1, "");
             TestGetPolicy(e, AsList(AsList("eve", "data3", "read")));
+
+            bool res = e.UpdatePolicy(AsList("eve", "data3", "read"), AsList("eve", "data3", "write"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy will not be updated.
+            res = e.UpdatePolicy(AsList("non_exist", "data3", "write"), AsList("non_exist", "data3", "read"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.False(res);
+
+            e.AddPolicies(rules);
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "write"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data4", "write"),
+                AsList("leyo", "data4", "read"),
+                AsList("ham", "data4", "write")));
+
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "write"),
+                    AsList("leyo", "data4", "read"),
+                    AsList("katy", "data4", "write")),
+                AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("katy", "data1", "write")));
+            TestGetPolicy(e, AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("jack", "data4", "read"),
+                    AsList("katy", "data1", "write"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("ham", "data4", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy in oldParameters will not be updated, so other existent ones
+            // will be ignored and the return value will be False.
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("non_exist", "data4", "read")),
+                AsList(
+                    AsList("eve", "data3", "write"), AsList("non_exist", "data4", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = e.UpdatePolicies(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("leyo", "data4", "write")),
+                AsList(AsList("eve", "data3", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
         }
 
         [Fact]
@@ -141,7 +203,7 @@ namespace Casbin.UnitTests.SyncedModelTests
             await e.RemovePolicyAsync("alice", "data1", "read");
             await e.AddPolicyAsync("eve", "data3", "read");
             await e.AddPolicyAsync("eve", "data3", "read");
-            
+
             var rules = AsList(
                 AsList("jack", "data4", "read"),
                 AsList("jack", "data4", "read"),
@@ -182,6 +244,68 @@ namespace Casbin.UnitTests.SyncedModelTests
             await e.RemoveFilteredPolicyAsync(1, "data2");
 
             TestGetPolicy(e, AsList(AsList("eve", "data3", "read")));
+
+            bool res = await e.UpdatePolicyAsync(AsList("eve", "data3", "read"), AsList("eve", "data3", "write"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy will not be updated.
+            res = await e.UpdatePolicyAsync(AsList("non_exist", "data3", "write"), AsList("non_exist", "data3", "read"));
+            TestGetPolicy(e, AsList(AsList("eve", "data3", "write")));
+            Assert.False(res);
+
+            await e.AddPoliciesAsync(rules);
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "write"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data4", "write"),
+                AsList("leyo", "data4", "read"),
+                AsList("ham", "data4", "write")));
+
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "write"),
+                    AsList("leyo", "data4", "read"),
+                    AsList("katy", "data4", "write")),
+                AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("katy", "data1", "write")));
+            TestGetPolicy(e, AsList(
+                    AsList("eve", "data3", "read"),
+                    AsList("jack", "data4", "read"),
+                    AsList("katy", "data1", "write"),
+                    AsList("leyo", "data4", "write"),
+                    AsList("ham", "data4", "write")));
+            Assert.True(res);
+
+            // This test shows that a non-existent policy in oldParameters will not be updated, so other existent ones
+            // will be ignored and the return value will be False.
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("non_exist", "data4", "read")),
+                AsList(
+                    AsList("eve", "data3", "write"), AsList("non_exist", "data4", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = await e.UpdatePoliciesAsync(
+                AsList(
+                    AsList("eve", "data3", "read"), AsList("leyo", "data4", "write")),
+                AsList(AsList("eve", "data3", "write")));
+            TestGetPolicy(e, AsList(
+                AsList("eve", "data3", "read"),
+                AsList("jack", "data4", "read"),
+                AsList("katy", "data1", "write"),
+                AsList("leyo", "data4", "write"),
+                AsList("ham", "data4", "write")));
+            Assert.False(res);
         }
 
         [Fact]
@@ -236,6 +360,58 @@ namespace Casbin.UnitTests.SyncedModelTests
             TestGetUsers(e, "data1_admin", AsList());
             TestGetUsers(e, "data2_admin", AsList());
             TestGetUsers(e, "data3_admin", AsList("eve"));
+
+            e.AddGroupingPolicy("data3_admin", "data4_admin");
+            bool res = e.UpdateGroupingPolicy(AsList("eve", "data3_admin"), AsList("eve", "admin"));
+            Assert.True(res);
+            res = e.UpdateGroupingPolicy(AsList("data3_admin", "data4_admin"), AsList("admin", "data4_admin"));
+            Assert.True(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+            TestGetUsers(e, "admin", AsList("eve"));
+            TestGetRoles(e, "eve", AsList("admin"));
+            TestGetRoles(e, "admin", AsList("data4_admin"));
+
+            res = e.UpdateGroupingPolicy(AsList("non_exist", "data4_admin"), AsList("non_exist2", "data4_admin"));
+            Assert.False(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("eve", "admin"),
+                    AsList("admin", "data4_admin")),
+                AsList(
+                    AsList("eve", "admin_groups"),
+                    AsList("admin", "data5_admin")));
+
+            Assert.True(res);
+            TestGetUsers(e, "data5_admin", AsList("admin"));
+            TestGetUsers(e, "admin_groups", AsList("eve"));
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("non_exist", "admin_groups")
+                    ),
+                AsList(
+                    AsList("admin", "data6_admin"),
+                    AsList("non_exist2", "admin_groups")
+                    ));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = e.UpdateGroupingPolicies(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("eve", "admin2_groups")),
+                AsList(
+                    AsList("admin", "data6_admin")));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
         }
 
         [Fact]
@@ -289,6 +465,58 @@ namespace Casbin.UnitTests.SyncedModelTests
             TestGetUsers(e, "data1_admin", AsList());
             TestGetUsers(e, "data2_admin", AsList());
             TestGetUsers(e, "data3_admin", AsList("eve"));
+
+            await e.AddGroupingPolicyAsync("data3_admin", "data4_admin");
+            bool res = await e.UpdateGroupingPolicyAsync(AsList("eve", "data3_admin"), AsList("eve", "admin"));
+            Assert.True(res);
+            res = await e.UpdateGroupingPolicyAsync(AsList("data3_admin", "data4_admin"), AsList("admin", "data4_admin"));
+            Assert.True(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+            TestGetUsers(e, "admin", AsList("eve"));
+            TestGetRoles(e, "eve", AsList("admin"));
+            TestGetRoles(e, "admin", AsList("data4_admin"));
+
+            res = await e.UpdateGroupingPolicyAsync(AsList("non_exist", "data4_admin"), AsList("non_exist2", "data4_admin"));
+            Assert.False(res);
+            TestGetUsers(e, "data4_admin", AsList("admin"));
+
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("eve", "admin"),
+                    AsList("admin", "data4_admin")),
+                AsList(
+                    AsList("eve", "admin_groups"),
+                    AsList("admin", "data5_admin")));
+
+            Assert.True(res);
+            TestGetUsers(e, "data5_admin", AsList("admin"));
+            TestGetUsers(e, "admin_groups", AsList("eve"));
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("non_exist", "admin_groups")
+                    ),
+                AsList(
+                    AsList("admin", "data6_admin"),
+                    AsList("non_exist2", "admin_groups")
+                    ));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
+
+            // If oldRules' length is not the same as newRules', no rules will be updated.
+            res = await e.UpdateGroupingPoliciesAsync(
+                AsList(
+                    AsList("admin", "data5_admin"),
+                    AsList("eve", "admin2_groups")),
+                AsList(
+                    AsList("admin", "data6_admin")));
+            Assert.False(res);
+            TestGetRoles(e, "admin", AsList("data5_admin"));
+            TestGetRoles(e, "eve", AsList("admin_groups"));
         }
     }
 }

--- a/Casbin/Abstractions/Model/IModel.cs
+++ b/Casbin/Abstractions/Model/IModel.cs
@@ -36,6 +36,17 @@ namespace Casbin.Model
             string section, string roleType, IEnumerable<string> rule);
 
         /// <summary>
+        /// Provides incremental build the role inheritance relation.
+        /// </summary>
+        /// <param name="policyOperation"></param>
+        /// <param name="section"></param>
+        /// <param name="roleType"></param>
+        /// <param name="oldRule"></param>
+        /// <param name="newRule"></param>
+        public void BuildIncrementalRoleLink(PolicyOperation policyOperation,
+            string section, string roleType, IEnumerable<string> oldRule, IEnumerable<string> newRule);
+
+        /// <summary>
         /// Provides incremental build the role inheritance relations.
         /// </summary>
         /// <param name="policyOperation"></param>
@@ -44,6 +55,17 @@ namespace Casbin.Model
         /// <param name="rules"></param>
         public void BuildIncrementalRoleLinks(PolicyOperation policyOperation,
             string section, string roleType, IEnumerable<IEnumerable<string>> rules);
+
+        /// <summary>
+        /// Provides incremental build the role inheritance relations.
+        /// </summary>
+        /// <param name="policyOperation"></param>
+        /// <param name="section"></param>
+        /// <param name="roleType"></param>
+        /// <param name="oldRules"></param>
+        /// <param name="newRules"></param>
+        public void BuildIncrementalRoleLinks(PolicyOperation policyOperation,
+            string section, string roleType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules);
 
         /// <summary>
         /// Initializes the roles in RBAC.

--- a/Casbin/Abstractions/Model/IPolicyManager.cs
+++ b/Casbin/Abstractions/Model/IPolicyManager.cs
@@ -46,6 +46,10 @@ namespace Casbin.Model
 
         public Task<bool> AddPoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
 
+        public Task<bool> UpdatePolicyAsync(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule);
+
+        public Task<bool> UpdatePoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules);
+
         public Task<bool> RemovePolicyAsync(string section, string policyType, IEnumerable<string> rule);
 
         public Task<bool> RemovePoliciesAsync(string section, string policyType,

--- a/Casbin/Abstractions/Model/IPolicyStore.cs
+++ b/Casbin/Abstractions/Model/IPolicyStore.cs
@@ -23,9 +23,15 @@ namespace Casbin.Model
 
         public bool HasPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
 
+        public bool HasAllPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
+
         public bool AddPolicy(string section, string policyType, IEnumerable<string> rule);
 
         public bool AddPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
+
+        public bool UpdatePolicy(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule);
+
+        public bool UpdatePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules);
 
         public bool RemovePolicy(string section, string policyType, IEnumerable<string> rule);
 

--- a/Casbin/Abstractions/Persist/IBatchAdapter.cs
+++ b/Casbin/Abstractions/Persist/IBatchAdapter.cs
@@ -9,6 +9,10 @@ namespace Casbin.Persist
 
         Task AddPoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
 
+        void UpdatePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules);
+
+        Task UpdatePoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules);
+
         void RemovePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules);
 
         Task RemovePoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> rules);

--- a/Casbin/Abstractions/Persist/ISingleAdapter.cs
+++ b/Casbin/Abstractions/Persist/ISingleAdapter.cs
@@ -9,6 +9,10 @@ namespace Casbin.Persist
 
         Task AddPolicyAsync(string section, string policyType, IEnumerable<string> rule);
 
+        void UpdatePolicy(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule);
+
+        Task UpdatePolicyAsync(string section, string policyType, IEnumerable<string> oldRules, IEnumerable<string> newRules);
+
         void RemovePolicy(string section, string policyType, IEnumerable<string> rule);
 
         Task RemovePolicyAsync(string section, string policyType, IEnumerable<string> rule);

--- a/Casbin/Extensions/Enforcer/ManagementEnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/ManagementEnforcerExtension.cs
@@ -363,6 +363,160 @@ namespace Casbin
 
         #endregion
 
+        #region Update Store
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdatePolicy(this IEnforcer enforcer, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdatePolicy(enforcer, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdatePolicyAsync(this IEnforcer enforcer, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdatePolicyAsync(enforcer, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdatePolicy(this IEnforcer enforcer, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return UpdateNamedPolicy(enforcer, PermConstants.DefaultPolicyType, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdatePolicyAsync(this IEnforcer enforcer, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return UpdateNamedPolicyAsync(enforcer, PermConstants.DefaultPolicyType, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedPolicy(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateNamedPolicy(enforcer, ptype, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateNamedPolicyAsync(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateNamedPolicyAsync(enforcer, ptype, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current named policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedPolicy(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return enforcer.InternalUpdatePolicy(PermConstants.Section.PolicySection, ptype, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates an authorization rule to the current named policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldParameters">The "p" policy rule to be replaced.</param>
+        /// <param name="newParameters">The "p" policy rule to replace the old one.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateNamedPolicyAsync(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return enforcer.InternalUpdatePolicyAsync(PermConstants.Section.PolicySection, ptype, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates authorization rules to the current policies.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldRules">The "p" policy rules to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newRules">The "p" policy rules to replace the old ones, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdatePolicies(this IEnforcer enforcer, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return UpdateNamedPolicies(enforcer, PermConstants.DefaultPolicyType, oldRules, newRules);
+        }
+
+        /// <summary>
+        /// Updates authorization rules to the current policies.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldRules">The "p" policy rules to be replaced, ptype "p" is implicitly used.</param>
+        /// <param name="newRules">The "p" policy rules to replace the old ones, ptype "p" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdatePoliciesAsync(this IEnforcer enforcer, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return UpdateNamedPoliciesAsync(enforcer, PermConstants.DefaultPolicyType, oldRules, newRules);
+        }
+
+        /// <summary>
+        /// Updates authorization rules to the current named policies.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldRules">The "p" policy rule to be replaced.</param>
+        /// <param name="newRules">The "p" policy rule to replace the old ones.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedPolicies(this IEnforcer enforcer, string ptype, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return enforcer.InternalUpdatePolicies(PermConstants.Section.PolicySection, ptype, oldRules, newRules);
+        }
+
+        /// <summary>
+        /// Updates authorization rules to the current named policies.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "p", "p2", "p3", ..</param>
+        /// <param name="oldRules">The "p" policy rule to be replaced.</param>
+        /// <param name="newRules">The "p" policy rule to replace the old ones.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateNamedPoliciesAsync(this IEnforcer enforcer, string ptype, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return enforcer.InternalUpdatePoliciesAsync(PermConstants.Section.PolicySection, ptype, oldRules, newRules);
+        }
+
+        #endregion
+
         #region Remove Store
 
         /// <summary>
@@ -748,7 +902,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds a named role inheritance rule to the current 
+        /// Adds a named role inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -762,7 +916,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds a named role inheritance rule to the current 
+        /// Adds a named role inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -776,7 +930,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds a named role inheritance rule to the current 
+        /// Adds a named role inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -790,7 +944,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds a named role inheritance rule to the current 
+        /// Adds a named role inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -830,7 +984,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds named roles inheritance rule to the current 
+        /// Adds named roles inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -844,7 +998,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Adds named roles inheritance rule to the current 
+        /// Adds named roles inheritance rule to the current
         /// policy. If the rule already exists, the function returns false and the rule
         /// will not be added. Otherwise the function returns true by adding the new rule.
         /// </summary>
@@ -855,6 +1009,162 @@ namespace Casbin
         public static async Task<bool> AddNamedGroupingPoliciesAsync(this IEnforcer enforcer, string ptype, IEnumerable<IEnumerable<string>> rules)
         {
             return await enforcer.InternalAddPoliciesAsync(PermConstants.Section.RoleSection, ptype, rules);
+        }
+
+        #endregion
+
+        #region Update Grouping/Role Store
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateGroupingPolicy(this IEnforcer enforcer, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateGroupingPolicy(enforcer, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateGroupingPolicyAsync(this IEnforcer enforcer, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateGroupingPolicyAsync(enforcer, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateGroupingPolicy(this IEnforcer enforcer, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return UpdateNamedGroupingPolicy(enforcer, PermConstants.DefaultGroupingPolicyType, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateGroupingPolicyAsync(this IEnforcer enforcer, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return UpdateNamedGroupingPolicyAsync(enforcer, PermConstants.DefaultGroupingPolicyType, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedGroupingPolicy(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateNamedGroupingPolicy(enforcer, ptype, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateNamedGroupingPolicyAsync(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, params string[] newParameters)
+        {
+            return UpdateNamedGroupingPolicyAsync(enforcer, ptype, oldParameters, newParameters as IEnumerable<string>);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedGroupingPolicy(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return enforcer.InternalUpdatePolicy(PermConstants.Section.RoleSection, ptype, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldParameters">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newParameters">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static async Task<bool> UpdateNamedGroupingPolicyAsync(this IEnforcer enforcer, string ptype, IEnumerable<string> oldParameters, IEnumerable<string> newParameters)
+        {
+            return await enforcer.InternalUpdatePolicyAsync(PermConstants.Section.RoleSection, ptype, oldParameters, newParameters);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldRules">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newRules">The "g" policy rule to replace the old ones, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateGroupingPolicies(this IEnforcer enforcer, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return UpdateNamedGroupingPolicies(enforcer, PermConstants.DefaultGroupingPolicyType, oldRules, newRules);
+
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="oldRules">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newRules">The "g" policy rule to replace the old one, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static Task<bool> UpdateGroupingPoliciesAsync(this IEnforcer enforcer, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return UpdateNamedGroupingPoliciesAsync(enforcer, PermConstants.DefaultGroupingPolicyType, oldRules, newRules);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldRules">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newRules">The "g" policy rule to replace the old ones, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static bool UpdateNamedGroupingPolicies(this IEnforcer enforcer, string ptype, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return enforcer.InternalUpdatePolicies(PermConstants.Section.RoleSection, ptype, oldRules, newRules);
+        }
+
+        /// <summary>
+        /// Updates a role inheritance rule from the current policy, field filters can be specified.
+        /// </summary>
+        /// <param name="enforcer"></param>
+        /// <param name="ptype">The policy type, can be "g", "g2", "g3", ..</param>
+        /// <param name="oldRules">The "g" policy rule to be replaced, ptype "g" is implicitly used.</param>
+        /// <param name="newRules">The "g" policy rule to replace the old ones, ptype "g" is implicitly used.</param>
+        /// <returns>Succeeds or not.</returns>
+        public static async Task<bool> UpdateNamedGroupingPoliciesAsync(this IEnforcer enforcer, string ptype,
+            IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            return await enforcer.InternalUpdatePoliciesAsync(PermConstants.Section.RoleSection, ptype, oldRules, newRules);
         }
 
         #endregion
@@ -906,7 +1216,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -919,7 +1229,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -932,7 +1242,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -941,11 +1251,11 @@ namespace Casbin
         /// <returns>Succeeds or not.</returns>
         public static bool RemoveNamedGroupingPolicy(this IEnforcer enforcer, string ptype, IEnumerable<string> parameters)
         {
-            return enforcer.InternalRemovePolicy(PermConstants.Section.RoleSection, ptype, parameters); ;
+            return enforcer.InternalRemovePolicy(PermConstants.Section.RoleSection, ptype, parameters);
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -954,7 +1264,7 @@ namespace Casbin
         /// <returns>Succeeds or not.</returns>
         public static async Task<bool> RemoveNamedGroupingPolicyAsync(this IEnforcer enforcer, string ptype, IEnumerable<string> parameters)
         {
-            return await enforcer.InternalRemovePolicyAsync(PermConstants.Section.RoleSection, ptype, parameters); ;
+            return await enforcer.InternalRemovePolicyAsync(PermConstants.Section.RoleSection, ptype, parameters);
         }
 
         /// <summary>
@@ -981,7 +1291,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes roles inheritance rule from the current 
+        /// Removes roles inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -994,7 +1304,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes roles inheritance rule from the current 
+        /// Removes roles inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -1007,7 +1317,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>
@@ -1020,7 +1330,7 @@ namespace Casbin
         }
 
         /// <summary>
-        /// Removes a role inheritance rule from the current 
+        /// Removes a role inheritance rule from the current
         /// policy, field filters can be specified.
         /// </summary>
         /// <param name="enforcer"></param>

--- a/Casbin/Model/DefaultModel.cs
+++ b/Casbin/Model/DefaultModel.cs
@@ -188,6 +188,28 @@ namespace Casbin.Model
         }
 
         /// <summary>
+        /// Provides incremental build the role inheritance relation.
+        /// </summary>
+        /// <param name="policyOperation"></param>
+        /// <param name="section"></param>
+        /// <param name="roleType"></param>
+        /// <param name="oldRule"></param>
+        /// <param name="newRule"></param>
+        public void BuildIncrementalRoleLink(PolicyOperation policyOperation,
+            string section, string roleType, IEnumerable<string> oldRule, IEnumerable<string> newRule)
+        {
+            if (Sections.ContainsKey(PermConstants.Section.RoleSection) is false)
+            {
+                return;
+            }
+
+            Assertion assertion = GetRequiredAssertion(section, roleType);
+            assertion.BuildIncrementalRoleLink(policyOperation, oldRule, newRule);
+
+            GFunctionCachePool.Clear(roleType);
+        }
+
+        /// <summary>
         /// Provides incremental build the role inheritance relations.
         /// </summary>
         /// <param name="policyOperation"></param>
@@ -204,6 +226,28 @@ namespace Casbin.Model
 
             Assertion assertion = GetRequiredAssertion(section, roleType);
             assertion.BuildIncrementalRoleLinks(policyOperation, rules);
+
+            GFunctionCachePool.Clear(roleType);
+        }
+
+        /// <summary>
+        /// Provides incremental build the role inheritance relations.
+        /// </summary>
+        /// <param name="policyOperation"></param>
+        /// <param name="section"></param>
+        /// <param name="roleType"></param>
+        /// <param name="oldRules"></param>
+        /// <param name="newRules"></param>
+        public void BuildIncrementalRoleLinks(PolicyOperation policyOperation,
+            string section, string roleType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            if (Sections.ContainsKey(PermConstants.Section.RoleSection) is false)
+            {
+                return;
+            }
+
+            Assertion assertion = GetRequiredAssertion(section, roleType);
+            assertion.BuildIncrementalRoleLinks(policyOperation, oldRules, newRules);
 
             GFunctionCachePool.Clear(roleType);
         }
@@ -317,11 +361,20 @@ namespace Casbin.Model
         public bool HasPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
             => PolicyManager.HasPolicies(section, policyType, rules);
 
+        public bool HasAllPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+            => PolicyManager.HasAllPolicies(section, policyType, rules);
+
         public bool AddPolicy(string section, string policyType, IEnumerable<string> rule)
             => PolicyManager.AddPolicy(section, policyType, rule);
 
         public bool AddPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
             => PolicyManager.AddPolicies(section, policyType, rules);
+
+        public bool UpdatePolicy(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule)
+            => PolicyManager.UpdatePolicy(section, policyType, oldRule, newRule);
+
+        public bool UpdatePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+            => PolicyManager.UpdatePolicies(section, policyType, oldRules, newRules);
 
         public bool RemovePolicy(string section, string policyType, IEnumerable<string> rule)
             => PolicyManager.RemovePolicy(section, policyType, rule);

--- a/Casbin/Model/DefaultPolicyManager.cs
+++ b/Casbin/Model/DefaultPolicyManager.cs
@@ -360,6 +360,19 @@ namespace Casbin.Model
             }
         }
 
+        public bool HasAllPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            StartRead();
+            try
+            {
+                return PolicyStore.HasAllPolicies(section, policyType, rules);
+            }
+            finally
+            {
+                EndRead();
+            }
+        }
+
         public bool AddPolicy(string section, string policyType, IEnumerable<string> rule)
         {
             if (TryStartWrite() is false)
@@ -401,6 +414,56 @@ namespace Casbin.Model
 
                 BatchAdapter?.AddPolicies(section, policyType, rulesArray);
                 return PolicyStore.AddPolicies(section, policyType, rulesArray);
+            }
+            finally
+            {
+                EndWrite();
+            }
+        }
+
+        public bool UpdatePolicy(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule)
+        {
+            if (TryStartWrite() is false)
+            {
+                return false;
+            }
+
+            try
+            {
+                IEnumerable<string> oldRuleArray = oldRule as string[] ?? oldRule.ToArray();
+                IEnumerable<string> newRuleArray = newRule as string[] ?? newRule.ToArray();
+                if (HasAdapter is false || AutoSave is false)
+                {
+                    return PolicyStore.UpdatePolicy(section, policyType, oldRuleArray, newRuleArray);
+                }
+
+                SingleAdapter?.UpdatePolicy(section, policyType, oldRuleArray, newRuleArray);
+                return PolicyStore.UpdatePolicy(section, policyType, oldRuleArray, newRuleArray);
+            }
+            finally
+            {
+                EndWrite();
+            }
+        }
+
+        public bool UpdatePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            if (TryStartWrite() is false)
+            {
+                return false;
+            }
+
+            try
+            {
+                var oldRulesArray = oldRules as IEnumerable<string>[] ?? oldRules.ToArray();
+                var newRulesArray = newRules as IEnumerable<string>[] ?? newRules.ToArray();
+                if (HasAdapter is false || AutoSave is false)
+                {
+                    return PolicyStore.UpdatePolicies(section, policyType, oldRulesArray, newRulesArray);
+                }
+
+                BatchAdapter?.UpdatePolicies(section, policyType, oldRulesArray, newRulesArray);
+                return PolicyStore.UpdatePolicies(section, policyType, oldRulesArray, newRulesArray);
             }
             finally
             {
@@ -530,6 +593,65 @@ namespace Casbin.Model
                 }
 
                 return PolicyStore.AddPolicies(section, policyType, rulesArray);
+            }
+            finally
+            {
+                EndWrite();
+            }
+        }
+
+        public virtual async Task<bool> UpdatePolicyAsync(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule)
+        {
+            if (TryStartWrite() is false)
+            {
+                return false;
+            }
+
+            try
+            {
+                IEnumerable<string> oldRuleArray = oldRule as string[] ?? oldRule.ToArray();
+                IEnumerable<string> newRuleArray = newRule as string[] ?? newRule.ToArray();
+                if (HasAdapter is false || AutoSave is false)
+                {
+                    return PolicyStore.UpdatePolicy(section, policyType, oldRuleArray, newRuleArray);
+                }
+
+                if (SingleAdapter is not null)
+                {
+                    await SingleAdapter.UpdatePolicyAsync(section, policyType, oldRuleArray, newRuleArray);
+                }
+
+                return PolicyStore.UpdatePolicy(section, policyType, oldRuleArray, newRuleArray);
+            }
+            finally
+            {
+                EndWrite();
+            }
+        }
+
+        public virtual async Task<bool> UpdatePoliciesAsync(string section, string policyType,
+            IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            if (TryStartWrite() is false)
+            {
+                return false;
+            }
+
+            try
+            {
+                var oldRulesArray = oldRules as IEnumerable<string>[] ?? oldRules.ToArray();
+                var newRulesArray = newRules as IEnumerable<string>[] ?? newRules.ToArray();
+                if (HasAdapter is false || AutoSave is false)
+                {
+                    return PolicyStore.UpdatePolicies(section, policyType, oldRulesArray, newRulesArray);
+                }
+
+                if (BatchAdapter is not null)
+                {
+                    await BatchAdapter.UpdatePoliciesAsync(section, policyType, oldRulesArray, newRulesArray);
+                }
+
+                return PolicyStore.UpdatePolicies(section, policyType, oldRulesArray, newRulesArray);
             }
             finally
             {

--- a/Casbin/Model/DefaultPolicyStore.cs
+++ b/Casbin/Model/DefaultPolicyStore.cs
@@ -95,6 +95,13 @@ namespace Casbin.Model
             return ruleArray.Length == 0 || ruleArray.Any(assertion.Contains);
         }
 
+        public bool HasAllPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            var assertion = GetRequiredAssertion(section, policyType);
+            var ruleArray = rules as IEnumerable<string>[] ?? rules.ToArray();
+            return ruleArray.Length == 0 || ruleArray.All(assertion.Contains);
+        }
+
         public bool AddPolicy(string section, string policyType, IEnumerable<string> rule)
         {
             var assertion = GetRequiredAssertion(section, policyType);
@@ -119,6 +126,35 @@ namespace Casbin.Model
             foreach (var rule in ruleArray)
             {
                 assertion.TryAddPolicy(rule);
+            }
+            return true;
+        }
+
+        public bool UpdatePolicy(string section, string policyType, IEnumerable<string> oldRule, IEnumerable<string> newRule)
+        {
+            var assertion = GetRequiredAssertion(section, policyType);
+            return assertion.TryUpdatePolicy(oldRule, newRule);
+        }
+
+        public bool UpdatePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> oldRules, IEnumerable<IEnumerable<string>> newRules)
+        {
+            if (oldRules is null)
+            {
+                throw new ArgumentNullException(nameof(oldRules));
+            }
+
+            var assertion = GetRequiredAssertion(section, policyType);
+            var oldRulesArray = oldRules as IEnumerable<string>[] ?? oldRules.ToArray();
+            var newRulesArray = newRules as IEnumerable<string>[] ?? newRules.ToArray();
+
+            if (oldRulesArray.Length != newRulesArray.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < oldRulesArray.Length; i++)
+            {
+                assertion.TryUpdatePolicy(oldRulesArray[i], newRulesArray[i]);
             }
             return true;
         }

--- a/Casbin/PolicyOperation.cs
+++ b/Casbin/PolicyOperation.cs
@@ -3,6 +3,7 @@
     public enum PolicyOperation
     {
         PolicyAdd,
-        PolicyRemove
+        PolicyRemove,
+        PolicyUpdate,
     }
 }


### PR DESCRIPTION
Fix: #182 

In addition, several new unit tests are also added, such as verifying return values, which Golang version seems not to cover. I've tried them with the Golang version and the results are basically the same.