### PR TITLE
feat: Support batch enforce and add corresponding test.

### DIFF
--- a/Casbin/Abstractions/IEnforcer.cs
+++ b/Casbin/Abstractions/IEnforcer.cs
@@ -1,15 +1,22 @@
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Casbin.Caching;
 using Casbin.Effect;
-using Casbin.Evaluation;
 using Casbin.Model;
 using Casbin.Persist;
 using Casbin.Rbac;
 #if !NET452
 using Microsoft.Extensions.Logging;
 #endif
+
 namespace Casbin
 {
+#if !NET452
+    using BatchEnforceAsyncResults = IAsyncEnumerable<bool>;
+#else
+    using BatchEnforceAsyncResults = Task<IEnumerable<bool>>;
+#endif
+
     /// <summary>
     /// IEnforcer is the API interface of Enforcer
     /// </summary>
@@ -60,5 +67,27 @@ namespace Casbin
         /// can be class instances if ABAC is used.</param>
         /// <returns>Whether to allow the request.</returns>
         public Task<bool> EnforceAsync<TRequest>(EnforceContext context, TRequest requestValues) where TRequest : IRequestValues;
+
+        /// <summary>
+        /// Decides whether some "subject" can access corresponding "object" with the operation
+        /// "action", input parameters are usually: (sub, obj, act).
+        /// </summary>
+        /// <param name="context">Enforce context include all status on enforcing</param>
+        /// <param name="requestValues">The requests needs to be mediated, whose element is usually an array of strings
+        /// but can be class instances if ABAC is used.</param>
+        /// <returns>Whether to allow the requests.</returns>
+        public IEnumerable<bool> BatchEnforce<TRequest>(EnforceContext context, IEnumerable<TRequest> requestValues) 
+            where TRequest : IRequestValues;
+
+        /// <summary>
+        /// Decides whether some "subject" can access corresponding "object" with the operation
+        /// "action", input parameters are usually: (sub, obj, act).
+        /// </summary>
+        /// <param name="context">Enforce context include all status on enforcing</param>
+        /// <param name="requestValues">The requests needs to be mediated, whose element is usually an array of strings
+        /// but can be class instances if ABAC is used.</param>
+        /// <returns>Whether to allow the requests.</returns>
+        public BatchEnforceAsyncResults BatchEnforceAsync<TRequest>(EnforceContext context, IEnumerable<TRequest> requestValues)
+            where TRequest : IRequestValues;
     }
 }

--- a/Casbin/Extensions/Enforcer/EnforceExtension.BatchEnforce.cs
+++ b/Casbin/Extensions/Enforcer/EnforceExtension.BatchEnforce.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Casbin.Model;
+
+namespace Casbin;
+
+#if !NET452
+using BatchEnforceAsyncResults = IAsyncEnumerable<bool>;
+#else
+using BatchEnforceAsyncResults = System.Threading.Tasks.Task<IEnumerable<bool>>;
+#endif
+
+public static partial class EnforcerExtension
+{
+    #region Batch Enforce Count 1
+
+    public static IEnumerable<bool> BatchEnforce<T>(this IEnforcer enforcer, IEnumerable<T> values) where T : IRequestValues
+    {
+        return enforcer.BatchEnforce(enforcer.CreateContext(), values);
+    }
+
+    public static IEnumerable<bool> ParallelBatchEnforce<T>(this Enforcer enforcer, IReadOnlyList<T> values, int maxDegreeOfParallelism = -1) 
+        where T : IRequestValues
+    {
+        return enforcer.ParallelBatchEnforce<T>(enforcer.CreateContext(), values, maxDegreeOfParallelism);
+    }
+
+    public static BatchEnforceAsyncResults BatchEnforceAsync<T>(this IEnforcer enforcer, IEnumerable<T> values) where T : IRequestValues
+    {
+        return enforcer.BatchEnforceAsync(enforcer.CreateContext(), values);
+    }
+
+    public static IEnumerable<bool> BatchEnforceWithMatcher<T>(this IEnforcer enforcer, string matcher, 
+        IEnumerable<T> values) where T : IRequestValues
+    {
+        EnforceContext context = enforcer.CreateContextWithMatcher(matcher);
+        return enforcer.BatchEnforce(context, values);
+    }
+
+    public static IEnumerable<bool> BatchEnforceWithMatcherParallel<T>(this Enforcer enforcer, string matcher, 
+        IReadOnlyList<T> values, int maxDegreeOfParallelism = -1) where T : IRequestValues
+    {
+        EnforceContext context = enforcer.CreateContextWithMatcher(matcher);
+        return enforcer.ParallelBatchEnforce(context, values, maxDegreeOfParallelism);
+    }
+
+    public static BatchEnforceAsyncResults BatchEnforceWithMatcherAsync<T>(this IEnforcer enforcer, string matcher, 
+        IEnumerable<T> values) where T : IRequestValues
+    {
+        EnforceContext context = enforcer.CreateContextWithMatcher(matcher);
+        return enforcer.BatchEnforceAsync(context, values);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Support batch enforce and add corresponding test. #166 

It used async stream to implement ```BatchEnforceAsync``` except ```NET452```.

It added ```BatchEnforceParallel``` in ```Enforcer``` without a corresponding interface in ```IEnforcer```. I'm not sure about the design here. What I think is that its only a special implementation so that adding it to ```IEnforcer``` may mean little.

As for the extension, I only provide methods which accept generic type inherited from ```IRequestValues```. The reason is that if I provide similar API with that of ```EnforceExtension.GenericEnforce```, users need to pass several ```IEnumerable```, such as ```e.BatchEnforce(List<T1>, List<T2>, List<T3>)```. Thus, consistency of the parameters is not actually ensured, which I think may not be a good practice. Please give some suggestions about it.

I'll PR a benchmark of it if the design is approved finally.