### PR TITLE
fix: Avoid to clear policy when the file does not exist.

### DIFF
--- a/Casbin.UnitTests/ModelTests/ModelTest.cs
+++ b/Casbin.UnitTests/ModelTests/ModelTest.cs
@@ -600,6 +600,21 @@ public class ModelTest
         Assert.False(e.Enforce(context, new { Age = 70 }, "data2", "read"));
     }
 
+    [Fact]
+    public void TestFailedToLoadPolicy()
+    {
+        var e = new Enforcer(TestModelFixture.GetNewTestModel(
+            _testModelFixture._rbacWithDenyModelText,
+            _testModelFixture._rbacWithDenyPolicyText));
+        e.BuildRoleLinks();
+        TestEnforce(e, "alice", "data2", "read", true);
+        TestEnforce(e, "bob", "data2", "write", true);
+        Assert.Throws<System.IO.FileNotFoundException>(() => e.SetAdapter(new Casbin.Adapter.File.FileAdapter("Not found")));
+        e.LoadPolicy();
+        TestEnforce(e, "alice", "data2", "read", true);
+        TestEnforce(e, "bob", "data2", "write", true);
+    }
+
     public class TestResource
     {
         public TestResource(string name, string owner)

--- a/Casbin/Adapter/File/FileFilteredAdapter.cs
+++ b/Casbin/Adapter/File/FileFilteredAdapter.cs
@@ -28,11 +28,6 @@ namespace Casbin.Adapter.File
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(FilePath))
-            {
-                throw new InvalidOperationException("invalid file path, file path cannot be empty");
-            }
-
             LoadFilteredPolicyFile(store, filter);
         }
 
@@ -43,17 +38,12 @@ namespace Casbin.Adapter.File
                 return LoadPolicyAsync(store);
             }
 
-            if (string.IsNullOrWhiteSpace(FilePath))
-            {
-                throw new InvalidOperationException("invalid file path, file path cannot be empty");
-            }
-
             return LoadFilteredPolicyFileAsync(store, filter);
         }
 
         private void LoadFilteredPolicyFile(IPolicyStore store, Filter filter)
         {
-            var reader = new StreamReader(new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            var reader = _byteArrayInputStream;
             while (reader.EndOfStream is false)
             {
                 string line = reader.ReadLine()?.Trim();
@@ -68,7 +58,7 @@ namespace Casbin.Adapter.File
 
         private async Task LoadFilteredPolicyFileAsync(IPolicyStore store, Filter filter)
         {
-            var reader = new StreamReader(new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            var reader = _byteArrayInputStream;
             while (reader.EndOfStream is false)
             {
                 string line = (await reader.ReadLineAsync())?.Trim();

--- a/Casbin/Extensions/Persist/PolicyStoreExtension.cs
+++ b/Casbin/Extensions/Persist/PolicyStoreExtension.cs
@@ -25,7 +25,7 @@ public static class PolicyStoreExtension
     // ReSharper disable once MemberCanBePrivate.Global
     public static bool TryLoadPolicyLine(this IPolicyStore store, IReadOnlyList<string> lineTokens)
     {
-        string type = lineTokens[0];
+        string type = lineTokens[0].Trim('\uFEFF','\u200B');
         string section = type.Substring(0, 1);
         IPolicyValues values = Policy.ValuesFrom(lineTokens.Skip(1).ToList());
         return store.TryGetAssertion(section, type, out Assertion assertion)


### PR DESCRIPTION
fix #183 

One of the ways to fix this issue is to load policy to a different ```PolicyStore``` and then swap it with the original one if it succeeds to load new polices. The other is to show the exception earlier to tell users such usage is invalid.

This PR takes the second one. Could you please help to see whether this solution is reasonable? @sagilio 