### PR TITLE
feat: add keyGet3 and correponding test.

### DIFF
--- a/Casbin.UnitTests/UtilTests/BuiltInFunctionTest.cs
+++ b/Casbin.UnitTests/UtilTests/BuiltInFunctionTest.cs
@@ -79,6 +79,54 @@ public class BuiltInFunctionTest
         new object[] { "/alice/all", "/:/all", "", ""}
     };
 
+    public static IEnumerable<object[]> KeyGet3TestData = new[]
+    {
+    new object[] { "/", "/{resource}", "resource", "" },
+
+    new object[] { "/resource1", "/{resource}", "resource", "resource1" },
+
+    new object[] { "/myid", "/{id}/using/{resId}", "id", "" },
+
+    new object[] { "/myid/using/myresid", "/{id}/using/{resId}", "id", "myid" },
+
+    new object[] { "/myid/using/myresid", "/{id}/using/{resId}", "resId", "myresid" },
+
+
+    new object[] { "/proxy/myid", "/proxy/{id}/*", "id", "" },
+
+    new object[] { "/proxy/myid/", "/proxy/{id}/*", "id", "myid" },
+
+    new object[] { "/proxy/myid/res", "/proxy/{id}/*", "id", "myid" },
+
+    new object[] { "/proxy/myid/res/res2", "/proxy/{id}/*", "id", "myid" },
+
+    new object[] { "/proxy/myid/res/res2/res3", "/proxy/{id}/*", "id", "myid" },
+
+    new object[] { "/proxy/", "/proxy/{id}/*", "id", "" },
+
+
+    new object[] { "/api/group1_group_name/project1_admin/info", "/api/{proj}_admin/info",
+        "proj", "" },
+
+    new object[] { "/{id/using/myresid", "/{id/using/{resId}", "resId", "myresid" },
+
+    new object[] { "/{id/using/myresid/status}", "/{id/using/{resId}/status}", "resId", "myresid" },
+
+
+    new object[] { "/proxy/myid/res/res2/res3", "/proxy/{id}/*/{res}", "res", "res3" },
+
+    new object[] { "/api/project1_admin/info", "/api/{proj}_admin/info", "proj", "project1" },
+
+    new object[] { "/api/group1_group_name/project1_admin/info", "/api/{g}_{gn}/{proj}_admin/info",
+        "g", "group1" },
+
+    new object[] { "/api/group1_group_name/project1_admin/info", "/api/{g}_{gn}/{proj}_admin/info",
+        "gn", "group_name" },
+
+    new object[] { "/api/group1_group_name/project1_admin/info", "/api/{g}_{gn}/{proj}_admin/info",
+        "proj", "project1" }
+    };
+
     public static IEnumerable<object[]> keyMatchTestData = new[]
     {
         new object[] { "/foo", "/foo", true }, new object[] { "/foo", "/foo*", true },
@@ -198,6 +246,12 @@ public class BuiltInFunctionTest
     public void TestKeyGet2(string key1, string key2, string pathVar, string expectedResult) =>
         Assert.Equal(expectedResult,
             BuiltInFunctions.KeyGet2(key1, key2, pathVar));
+
+    [Theory]
+    [MemberData(nameof(KeyGet3TestData))]
+    public void TestKeyGet3(string key1, string key2, string pathVar, string expectedResult) =>
+        Assert.Equal(expectedResult,
+            BuiltInFunctions.KeyGet3(key1, key2, pathVar));
 
     [Theory]
     [MemberData(nameof(keyMatchTestData))]

--- a/Casbin/Model/FunctionMap.cs
+++ b/Casbin/Model/FunctionMap.cs
@@ -22,6 +22,7 @@ namespace Casbin.Model
 
             map.AddFunction("keyGet", BuiltInFunctions.KeyGet);
             map.AddFunction("keyGet2", BuiltInFunctions.KeyGet2);
+            map.AddFunction("keyGet3", BuiltInFunctions.KeyGet3);
             map.AddFunction("keyMatch", BuiltInFunctions.KeyMatch);
             map.AddFunction("keyMatch2", BuiltInFunctions.KeyMatch2);
             map.AddFunction("keyMatch3", BuiltInFunctions.KeyMatch3);


### PR DESCRIPTION
Add ```keyGet3``` and corresponding test. It's a feature synced with [this PR of go version](https://github.com/casbin/casbin/pull/1050).

BTW, it move the regex of ```keyGet2``` to the static readonly variable of the class.