### PR TITLE
feat: change lazyLoadPolicy to AutoLoadPolicy.

### DIFF
--- a/Casbin.UnitTests/ModelTests/EnforcerTest.cs
+++ b/Casbin.UnitTests/ModelTests/EnforcerTest.cs
@@ -61,7 +61,7 @@ public class EnforcerTest
     }
 
     [Fact]
-    public void TestEnforceWithLazyLoadPolicy()
+    public void TestEnforceWithoutAutoLoadPolicy()
     {
         IModel m = DefaultModel.Create();
         m.AddDef("r", "r", "sub, obj, act");
@@ -71,7 +71,7 @@ public class EnforcerTest
 
         FileAdapter a = new("examples/keymatch_policy.csv");
 
-        IEnforcer e = DefaultEnforcer.Create(m, a, true);
+        IEnforcer e = DefaultEnforcer.Create(m, a, options => { options.AutoLoadPolicy = false; });
         Assert.Empty(e.GetPolicy());
 
         e = DefaultEnforcer.Create(m, a);

--- a/Casbin/Abstractions/IEnforcer.cs
+++ b/Casbin/Abstractions/IEnforcer.cs
@@ -22,6 +22,18 @@ namespace Casbin
     /// </summary>
     public interface IEnforcer
     {
+        public class EnforcerOptions
+        {
+            public bool Enabled { get; set; } = true;
+            public bool EnabledCache { get; set; } = true;
+
+            public bool AutoBuildRoleLinks { get; set; } = true;
+            public bool AutoNotifyWatcher { get; set; } = true;
+            public bool AutoCleanEnforceCache { get; set; } = true;
+            public bool AutoLoadPolicy { get; set; } = true;
+            public Filter AutoLoadPolicyFilter { get; set; } = null;
+        }
+
         /// <summary>
         ///     Decides whether a "subject" can access a "object" with the operation
         ///     "action", input parameters are usually: (sub, obj, act).
@@ -76,6 +88,7 @@ namespace Casbin
 
         #region Options
 
+        public EnforcerOptions Options { get; set; }
         public bool Enabled { get; set; }
         public bool EnabledCache { get; set; }
         public bool AutoBuildRoleLinks { get; set; }

--- a/Casbin/DefaultEnforcer.cs
+++ b/Casbin/DefaultEnforcer.cs
@@ -1,28 +1,29 @@
-﻿using Casbin.Model;
+﻿using System;
+using Casbin.Model;
 using Casbin.Persist;
 
 namespace Casbin
 {
     public static class DefaultEnforcer
     {
-        public static IEnforcer Create(IReadOnlyAdapter adapter = null, bool lazyLoadPolicy = false)
+        public static IEnforcer Create(IReadOnlyAdapter adapter = null, Action<IEnforcer.EnforcerOptions> optionSettings = null)
         {
-            return new Enforcer(DefaultModel.Create(), adapter, lazyLoadPolicy);
+            return new Enforcer(DefaultModel.Create(), adapter, optionSettings);
         }
 
-        public static IEnforcer Create(string modelPath, string policyPath, bool lazyLoadPolicy = false)
+        public static IEnforcer Create(string modelPath, string policyPath, Action<IEnforcer.EnforcerOptions> optionSettings = null)
         {
-            return new Enforcer(modelPath, policyPath, lazyLoadPolicy);
+            return new Enforcer(modelPath, policyPath, optionSettings);
         }
 
-        public static IEnforcer Create(string modelPath, IReadOnlyAdapter adapter = null, bool lazyLoadPolicy = false)
+        public static IEnforcer Create(string modelPath, IReadOnlyAdapter adapter = null, Action<IEnforcer.EnforcerOptions> optionSettings = null)
         {
-            return new Enforcer(modelPath, adapter, lazyLoadPolicy);
+            return new Enforcer(modelPath, adapter, optionSettings);
         }
 
-        public static IEnforcer Create(IModel model, IReadOnlyAdapter adapter = null, bool lazyLoadPolicy = false)
+        public static IEnforcer Create(IModel model, IReadOnlyAdapter adapter = null, Action<IEnforcer.EnforcerOptions> optionSettings = null)
         {
-            return new Enforcer(model, adapter, lazyLoadPolicy);
+            return new Enforcer(model, adapter, optionSettings);
         }
     }
 }

--- a/Casbin/Extensions/Enforcer/EnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/EnforcerExtension.cs
@@ -42,7 +42,7 @@ namespace Casbin
         /// <param name="enable"></param>
         public static IEnforcer EnableEnforce(this IEnforcer enforcer, bool enable)
         {
-            enforcer.Enabled = enable;
+            enforcer.Options.Enabled = enable;
             return enforcer;
         }
 
@@ -66,7 +66,7 @@ namespace Casbin
         /// <param name="autoBuildRoleLinks">Whether to automatically build the role links.</param>
         public static IEnforcer EnableAutoBuildRoleLinks(this IEnforcer enforcer, bool autoBuildRoleLinks)
         {
-            enforcer.AutoBuildRoleLinks = autoBuildRoleLinks;
+            enforcer.Options.AutoBuildRoleLinks = autoBuildRoleLinks;
             return enforcer;
         }
 
@@ -78,19 +78,19 @@ namespace Casbin
         /// <param name="autoNotifyWatcher">Whether to automatically notify watcher.</param>
         public static IEnforcer EnableAutoNotifyWatcher(this IEnforcer enforcer, bool autoNotifyWatcher)
         {
-            enforcer.AutoNotifyWatcher = autoNotifyWatcher;
+            enforcer.Options.AutoNotifyWatcher = autoNotifyWatcher;
             return enforcer;
         }
 
         public static IEnforcer EnableCache(this IEnforcer enforcer, bool enableCache)
         {
-            enforcer.EnabledCache = enableCache;
+            enforcer.Options.EnabledCache = enableCache;
             return enforcer;
         }
 
         public static IEnforcer EnableAutoCleanEnforceCache(this IEnforcer enforcer, bool autoCleanEnforceCache)
         {
-            enforcer.AutoCleanEnforceCache = autoCleanEnforceCache;
+            enforcer.Options.AutoCleanEnforceCache = autoCleanEnforceCache;
             return enforcer;
         }
 
@@ -186,7 +186,7 @@ namespace Casbin
 
             enforcer.ClearCache();
             enforcer.Model.SortPolicy();
-            if (enforcer.AutoBuildRoleLinks)
+            if (enforcer.Options.AutoBuildRoleLinks)
             {
                 enforcer.BuildRoleLinks();
             }
@@ -207,7 +207,7 @@ namespace Casbin
 
             enforcer.ClearCache();
             enforcer.Model.SortPolicy();
-            if (enforcer.AutoBuildRoleLinks)
+            if (enforcer.Options.AutoBuildRoleLinks)
             {
                 enforcer.BuildRoleLinks();
             }
@@ -229,7 +229,7 @@ namespace Casbin
                 return false;
             }
 
-            if (enforcer.AutoBuildRoleLinks)
+            if (enforcer.Options.AutoBuildRoleLinks)
             {
                 enforcer.BuildRoleLinks();
             }
@@ -251,7 +251,7 @@ namespace Casbin
                 return false;
             }
 
-            if (enforcer.AutoBuildRoleLinks)
+            if (enforcer.Options.AutoBuildRoleLinks)
             {
                 enforcer.BuildRoleLinks();
             }
@@ -336,7 +336,7 @@ namespace Casbin
         public static void SetRoleManager(this IEnforcer enforcer, string roleType, IRoleManager roleManager)
         {
             enforcer.Model.SetRoleManager(roleType, roleManager);
-            if (enforcer.AutoBuildRoleLinks)
+            if (enforcer.Options.AutoBuildRoleLinks)
             {
                 enforcer.BuildRoleLinks();
             }

--- a/Casbin/Extensions/Enforcer/InternalEnforcerExtension.Events.cs
+++ b/Casbin/Extensions/Enforcer/InternalEnforcerExtension.Events.cs
@@ -71,7 +71,7 @@ namespace Casbin
 
         internal static void TryCleanEnforceCache(this IEnforcer enforcer)
         {
-            if (enforcer.AutoCleanEnforceCache)
+            if (enforcer.Options.AutoCleanEnforceCache)
             {
                 enforcer.ClearCache();
             }
@@ -80,7 +80,7 @@ namespace Casbin
         internal static void TryNotifyPolicyChanged(this IEnforcer enforcer, PolicyChangedMessage message)
         {
             // ReSharper disable once InvertIf
-            if (enforcer.AutoNotifyWatcher && enforcer.Watcher is not null)
+            if (enforcer.Options.AutoNotifyWatcher && enforcer.Watcher is not null)
             {
                 WatcherHolder holder = enforcer.Model.WatcherHolder;
                 if (holder.WatcherEx is not null)
@@ -105,7 +105,7 @@ namespace Casbin
 
         internal static async Task TryNotifyPolicyChangedAsync(this IEnforcer enforcer, PolicyChangedMessage message)
         {
-            if (enforcer.AutoNotifyWatcher && enforcer.Watcher is not null)
+            if (enforcer.Options.AutoNotifyWatcher && enforcer.Watcher is not null)
             {
                 WatcherHolder holder = enforcer.Model.WatcherHolder;
                 if (holder.WatcherEx is not null)


### PR DESCRIPTION
Change lazyLoadPolicy to AutoLoadPolicy to avoid ignore the filter when using filtered adapter. (partially solve #288 ).

Besides, it integrates the options into ```Enforcer.Options```.