### PR TITLE
feat: Support multi-line mode with '\' line feeds

### DIFF
--- a/Casbin.UnitTests/Casbin.UnitTests.csproj
+++ b/Casbin.UnitTests/Casbin.UnitTests.csproj
@@ -225,6 +225,12 @@
     <None Update="examples\comma_quotations_policy.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="examples\backslash_feed_model.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\backslash_feed_policy.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Casbin.UnitTests/Fixtures/TestModelFixture.cs
+++ b/Casbin.UnitTests/Fixtures/TestModelFixture.cs
@@ -89,10 +89,14 @@ public class TestModelFixture
     internal readonly string _supportCountModelText = ReadTestFile("support_count_model.conf");
 
     // https://github.com/casbin/Casbin.NET/issues/308
-    internal readonly string _RbacTokensWithSubstringRelationModelText = ReadTestFile("tokens_with_substring_relation_rbac.conf");
-    internal readonly string _RbacTokensWithSubstringRelationPolicyText = ReadTestFile("tokens_with_substring_relation_rbac.csv");
-    internal readonly string _AbacTokensWithSubstringRelationModelText = ReadTestFile("tokens_with_substring_relation_abac.conf");
-    internal readonly string _AbacTokensWithSubstringRelationPolicyText = ReadTestFile("tokens_with_substring_relation_abac.csv");
+    internal readonly string _rbacTokensWithSubstringRelationModelText = ReadTestFile("tokens_with_substring_relation_rbac.conf");
+    internal readonly string _rbacTokensWithSubstringRelationPolicyText = ReadTestFile("tokens_with_substring_relation_rbac.csv");
+    internal readonly string _abacTokensWithSubstringRelationModelText = ReadTestFile("tokens_with_substring_relation_abac.conf");
+    internal readonly string _abacTokensWithSubstringRelationPolicyText = ReadTestFile("tokens_with_substring_relation_abac.csv");
+
+    // https://github.com/casbin/Casbin.NET/issues/321
+    internal readonly string _backslashLineFeedModelText = ReadTestFile("backslash_feed_model.conf");
+    internal readonly string _backslashLineFeedPolicyText = ReadTestFile("backslash_feed_policy.csv");
 
     public IModel GetNewAbacModel() => GetNewTestModel(_abacModelText);
 

--- a/Casbin.UnitTests/ModelTests/ModelTest.cs
+++ b/Casbin.UnitTests/ModelTests/ModelTest.cs
@@ -648,8 +648,8 @@ public class ModelTest
     public void TestRbacTokensWithSubstringRelation()
     {
         Enforcer e = new(TestModelFixture.GetNewTestModel(
-            _testModelFixture._RbacTokensWithSubstringRelationModelText,
-            _testModelFixture._RbacTokensWithSubstringRelationPolicyText));
+            _testModelFixture._rbacTokensWithSubstringRelationModelText,
+            _testModelFixture._rbacTokensWithSubstringRelationPolicyText));
         e.BuildRoleLinks();
 
         TestDomainEnforce(e, "alice", "tenant1", "data1", "read", true);
@@ -666,8 +666,8 @@ public class ModelTest
     public void TestAbacTokensWithSubstringRelation()
     {
         Enforcer e = new(TestModelFixture.GetNewTestModel(
-            _testModelFixture._AbacTokensWithSubstringRelationModelText,
-            _testModelFixture._AbacTokensWithSubstringRelationPolicyText));
+            _testModelFixture._abacTokensWithSubstringRelationModelText,
+            _testModelFixture._abacTokensWithSubstringRelationPolicyText));
 
         TestResource data1 = new("data1", "alice");
         TestResource data2 = new("data2", "bob");
@@ -692,6 +692,24 @@ public class ModelTest
         TestEnforce(e, subjectd, data1, "read", false);
         TestEnforce(e, subjecte, data2, "write", false);
     }
+
+    [Fact]
+    public void TestBackslashLineFeed()
+    {
+        Enforcer e = new(TestModelFixture.GetNewTestModel(
+            _testModelFixture._backslashLineFeedModelText,
+            _testModelFixture._backslashLineFeedPolicyText));
+
+        TestEnforce(e, "alice", "data1", "read", true);
+        TestEnforce(e, "alice", "data1", "write", false);
+        TestEnforce(e, "alice", "data2", "read", false);
+        TestEnforce(e, "alice", "data2", "write", false);
+        TestEnforce(e, "bob", "data1", "read", false);
+        TestEnforce(e, "bob", "data1", "write", false);
+        TestEnforce(e, "bob", "data2", "read", false);
+        TestEnforce(e, "bob", "data2", "write", true);
+    }
+
     public class TestResource
     {
         public TestResource(string name, string owner)

--- a/Casbin.UnitTests/examples/backslash_feed_model.conf
+++ b/Casbin.UnitTests/examples/backslash_feed_model.conf
@@ -1,0 +1,21 @@
+[request_definition]
+r = sub, \
+obj, act
+
+[policy_definition]
+p = sub, \
+ obj,\
+act
+
+[policy_effect]
+e = som\
+e(where \
+(p.eft \
+== allow))
+
+[matchers]
+m = r.sub == p.sub\
+&& r.obj =\
+= p.obj && r.\
+act == p\
+.act

--- a/Casbin.UnitTests/examples/backslash_feed_policy.csv
+++ b/Casbin.UnitTests/examples/backslash_feed_policy.csv
@@ -1,0 +1,2 @@
+p, alice, data1, read
+p, bob, data2, write


### PR DESCRIPTION
Support multi-line mode with '\\' line feeds and fix two improperly named variables