### PR TITLE
fix: Accidental cache read via key construction

### DIFF
--- a/Casbin.UnitTests/ModelTests/ModelTest.cs
+++ b/Casbin.UnitTests/ModelTests/ModelTest.cs
@@ -719,6 +719,16 @@ public class ModelTest
         TestEnforce(e, "bob", "data2", "write", true);
     }
 
+    [Fact]
+    public void TestAccidentalCacheRead()
+    {
+        Enforcer e = new(_testModelFixture.GetBasicTestModel());
+
+        TestEnforce(e, "alice", "data1", "read", true);
+        TestEnforce(e, "aliced", "ata1", "read", false);
+        TestEnforce(e, "alice", "data", "1read", false);
+    }
+
     public class TestResource
     {
         public TestResource(string name, string owner)

--- a/Casbin/Model/Request.cs
+++ b/Casbin/Model/Request.cs
@@ -129,7 +129,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values2.Value1, "$", values2.Value2);
+                key = string.Concat(values2.Value1, "$$", values2.Value2);
                 return true;
             case 3:
                 if (requestValues is not RequestValues<string, string, string> values3)
@@ -138,7 +138,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values3.Value1, "$", values3.Value2, "$", values3.Value3);
+                key = string.Concat(values3.Value1, "$$", values3.Value2, "$$", values3.Value3);
                 return true;
             case 4:
                 if (requestValues is not RequestValues<string, string, string, string> values4)
@@ -147,7 +147,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values4.Value1, "$", values4.Value2, "$", values4.Value3, "$", values4.Value4);
+                key = string.Concat(values4.Value1, "$$", values4.Value2, "$$", values4.Value3, "$$", values4.Value4);
                 return true;
         }
 

--- a/Casbin/Model/Request.cs
+++ b/Casbin/Model/Request.cs
@@ -129,7 +129,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values2.Value1, values2.Value2);
+                key = string.Concat(values2.Value1, "$", values2.Value2);
                 return true;
             case 3:
                 if (requestValues is not RequestValues<string, string, string> values3)
@@ -138,7 +138,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values3.Value1, values3.Value2, values3.Value3);
+                key = string.Concat(values3.Value1, "$", values3.Value2, "$", values3.Value3);
                 return true;
             case 4:
                 if (requestValues is not RequestValues<string, string, string, string> values4)
@@ -147,7 +147,7 @@ public static class Request
                     return false;
                 }
 
-                key = string.Concat(values4.Value1, values4.Value2, values4.Value3, values4.Value4);
+                key = string.Concat(values4.Value1, "$", values4.Value2, "$", values4.Value3, "$", values4.Value4);
                 return true;
         }
 


### PR DESCRIPTION
Since the key was created without adding a separator, it was possible to have illegitimate access to the cache by way of collocation. This is now fixed with reference to the go language version.
However, in order to solve this problem at all, I think it should be explicitly mentioned in the documentation that fields should not contain '$'; or the separator should be replaced with a hash value (string hash) associated with the field.