### PR TITLE
feat: Change to Microsoft.Extensions.Configuration.Ini resolution .conf

### DIFF
--- a/Casbin/Casbin.csproj
+++ b/Casbin/Casbin.csproj
@@ -51,8 +51,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.5.23280.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
@@ -63,47 +63,47 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.32" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.32" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>

--- a/Casbin/Casbin.csproj
+++ b/Casbin/Casbin.csproj
@@ -37,77 +37,86 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="casbin.snk"/>
-    <None Remove="Casbin.csproj.DotSettings"/>
+    <None Remove="casbin.snk" />
+    <None Remove="Casbin.csproj.DotSettings" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="30.0.1"/>
-    <PackageReference Include="DotNet.Glob" Version="3.1.3"/>
-    <PackageReference Include="System.Memory" Version="4.5.5"/>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="DotNet.Glob" Version="3.1.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.5.23280.8"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.5.23280.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.32"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.32" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="DynamicExpresso.Core" Version="2.10.0"/>
-    <PackageReference Include="System.ValueTuple" Version="4.5.0"/>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all"/>
+    <PackageReference Include="DynamicExpresso.Core" Version="2.10.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="" />
-    <None Include="casbin.png" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="casbin.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
 

--- a/Casbin/Config/DefaultConfig.cs
+++ b/Casbin/Config/DefaultConfig.cs
@@ -1,6 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
+#if !NET452
+using Microsoft.Extensions.Configuration;
+using static System.Net.Mime.MediaTypeNames;
+#endif
 
 namespace Casbin.Config
 {
@@ -48,7 +54,7 @@ namespace Casbin.Config
         public static IConfig CreateFromText(string text)
         {
             var config = new DefaultConfig();
-            config.ParseBuffer(new StringReader(text));
+            config.ParseBuffer(config.ParseStringInit(new StringReader(text)));
             return config;
         }
 
@@ -159,26 +165,51 @@ namespace Casbin.Config
 
         private void Parse(string configFilePath)
         {
-            using (var sr = new StreamReader(configFilePath))
-            {
-                ParseBuffer(sr);
-            }
+            ParseBuffer(ParseStringInit(new StreamReader(configFilePath)));
         }
 
-        private void ParseBuffer(TextReader reader)
+        private MemoryStream ParseStringInit(TextReader textReader)
         {
-            string section = string.Empty;
+            TextWriter textWriter = new StringWriter();
+            string line;
+            string processedValue = string.Empty;
+            while ((line = textReader.ReadLine()) != null)
+            {
+                line = line.Split(_defaultComment[0]).First().Trim();
+                if (line.EndsWith(_defaultFeed))
+                {
+                    processedValue += line.Split(_defaultFeed[0]).First();
+                }
+                else
+                {
+                    processedValue += line;
+                    textWriter.WriteLine(processedValue);
+                    processedValue = string.Empty;
+                }
+            }
+            if (processedValue != string.Empty)
+            {
+                textWriter.WriteLine(processedValue);
+            }
+            return new MemoryStream(Encoding.UTF8.GetBytes(textWriter.ToString()));
+        }
+
+        private void ParseBuffer(Stream reader)
+        {
+#if NET452
+string section = string.Empty;
             int lineNum = 0;
             string line;
             bool inSuccessiveLine = false;
             string option = string.Empty;
             string processedValue = string.Empty;
+            TextReader textReader = new StreamReader(reader);
             while (true)
             {
                 lineNum++;
                 try
                 {
-                    if ((line = reader.ReadLine()) != null)
+                    if ((line = textReader.ReadLine()) != null)
                     {
                         if (string.IsNullOrEmpty(line))
                         {
@@ -257,7 +288,22 @@ namespace Casbin.Config
                     }
                 }
             }
-        }
+#else
+            IConfigurationBuilder builder = new ConfigurationBuilder().AddIniStream(reader);
+            IConfigurationRoot configuration = builder.Build();
+            var sections = configuration.GetChildren().ToList();
 
+            foreach (var section in sections)
+            {
+                foreach (var kvPair in section.AsEnumerable())
+                {
+                    if (kvPair.Value is not null)
+                    {
+                        AddConfig(section.Path, kvPair.Key.Split(':').Last().Trim(), kvPair.Value.Trim());
+                    }
+                }
+            }
+#endif
+        }
     }
 }

--- a/Casbin/Config/DefaultConfig.cs
+++ b/Casbin/Config/DefaultConfig.cs
@@ -176,8 +176,8 @@ namespace Casbin.Config
             TextWriter textWriter = new StringWriter();
             string line;
             string processedValue = string.Empty;
-            StreamReader streamreader = new StreamReader(stream);
-            while ((line = streamreader.ReadLine()) != null)
+            using var streamReader = new StreamReader(stream);
+            while ((line = streamReader.ReadLine()) != null)
             {
                 line = line.Split(_defaultComment[0]).First().Trim();
                 if (line.EndsWith(_defaultFeed))
@@ -198,7 +198,7 @@ namespace Casbin.Config
             return new MemoryStream(Encoding.UTF8.GetBytes(textWriter.ToString()));
         }
 
-        private void AddStream(Stream steam)
+        private void AddStream(Stream stream)
         {
 #if NET452
             string section = string.Empty;
@@ -207,13 +207,13 @@ namespace Casbin.Config
             bool inSuccessiveLine = false;
             string option = string.Empty;
             string processedValue = string.Empty;
-            TextReader textReader = new StreamReader(steam);
+            using var streamReader = new StreamReader(stream);
             while (true)
             {
                 lineNum++;
                 try
                 {
-                    if ((line = textReader.ReadLine()) != null)
+                    if ((line = streamReader.ReadLine()) != null)
                     {
                         if (string.IsNullOrEmpty(line))
                         {
@@ -293,7 +293,7 @@ namespace Casbin.Config
                 }
             }
 #else
-            IConfigurationBuilder builder = new ConfigurationBuilder().AddIniStream(steam);
+            IConfigurationBuilder builder = new ConfigurationBuilder().AddIniStream(stream);
             IConfigurationRoot configuration = builder.Build();
             var sections = configuration.GetChildren().ToList();
 

--- a/Casbin/Config/DefaultConfig.cs
+++ b/Casbin/Config/DefaultConfig.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 #if !NET452
 using Microsoft.Extensions.Configuration;
-using static System.Net.Mime.MediaTypeNames;
 #endif
 
 namespace Casbin.Config


### PR DESCRIPTION
Since the library can't handle newlines and comments, the ParseStringInit method processes the string first and then feeds it into ParseBuffer. in addition, since the library doesn't support net452, it retains the old parse method.


Fix: https://github.com/casbin/Casbin.NET/issues/264