### PR TITLE
feat: Add Matching Funcs to IEnforcer interface

### DIFF
--- a/Casbin/Extensions/Enforcer/EnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/EnforcerExtension.cs
@@ -342,30 +342,26 @@ namespace Casbin
             }
         }
 
-        public static IEnforcer AddMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
+        public static void AddMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
         {
             enforcer.AddNamedMatchingFunc(PermConstants.DefaultRoleType, func);
-            return enforcer;
         }
 
-        public static IEnforcer AddDomainMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
+        public static void AddDomainMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
         {
             enforcer.AddNamedDomainMatchingFunc(PermConstants.DefaultRoleType, func);
-            return enforcer;
         }
 
-        public static IEnforcer AddNamedMatchingFunc(this IEnforcer enforcer, string roleType,
+        public static void AddNamedMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
             enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);
-            return enforcer;
         }
 
-        public static IEnforcer AddNamedDomainMatchingFunc(this IEnforcer enforcer, string roleType,
+        public static void AddNamedDomainMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
             enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);
-            return enforcer;
         }
 
         #endregion

--- a/Casbin/Extensions/Enforcer/EnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/EnforcerExtension.cs
@@ -342,26 +342,26 @@ namespace Casbin
             }
         }
 
-        public static Enforcer AddMatchingFunc(this Enforcer enforcer, Func<string, string, bool> func)
+        public static IEnforcer AddMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
         {
             enforcer.AddNamedMatchingFunc(PermConstants.DefaultRoleType, func);
             return enforcer;
         }
 
-        public static Enforcer AddDomainMatchingFunc(this Enforcer enforcer, Func<string, string, bool> func)
+        public static IEnforcer AddDomainMatchingFunc(this IEnforcer enforcer, Func<string, string, bool> func)
         {
             enforcer.AddNamedDomainMatchingFunc(PermConstants.DefaultRoleType, func);
             return enforcer;
         }
 
-        public static Enforcer AddNamedMatchingFunc(this Enforcer enforcer, string roleType,
+        public static IEnforcer AddNamedMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
             enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);
             return enforcer;
         }
 
-        public static Enforcer AddNamedDomainMatchingFunc(this Enforcer enforcer, string roleType,
+        public static IEnforcer AddNamedDomainMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
             enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);


### PR DESCRIPTION
The IEnforcer did not have the `AddMatchingFunc`, `AddDomainMatchingFunc`, `AddNamedMatchingFunc`, or `AddNamedDomainMatchingFunc` in its interface. These are also returning the enforcer which isn't consistent with the Go implementation and seems unnecessary unless you are looking to chain the funcs.