### PR TITLE
feat: fix call to AddDomainMatchingFunc()

### DIFF
--- a/Casbin.UnitTests/Util/TestUtil.cs
+++ b/Casbin.UnitTests/Util/TestUtil.cs
@@ -32,7 +32,7 @@ public static class TestUtil
     internal static void TestParallelBatchEnforce<T>(Enforcer e, IEnumerable<(T, bool)> values) where T : IRequestValues =>
         Assert.True(values.Select(x => x.Item2).SequenceEqual(e.ParallelBatchEnforce(values.Select(x => x.Item1).ToList())));
 
-    internal static async void TestBatchEnforceAsync<T>(IEnforcer e, IEnumerable<(T, bool)> values) where T : IRequestValues 
+    internal static async void TestBatchEnforceAsync<T>(IEnforcer e, IEnumerable<(T, bool)> values) where T : IRequestValues
     {
 #if !NET452
         var res = e.BatchEnforceAsync(values.Select(x => x.Item1));
@@ -42,7 +42,7 @@ public static class TestUtil
         var expectedResults = values.Select(x => x.Item2);
         var expectedResultEnumerator = expectedResults.GetEnumerator();
 #if !NET452
-        await foreach(var item in res)
+        await foreach (var item in res)
 #else
         foreach(var item in res)
 #endif
@@ -60,17 +60,17 @@ public static class TestUtil
 
     internal static async Task TestEnforceWithMatcherAsync<T1, T2, T3>(this IEnforcer e, string matcher, T1 sub, T2 obj,
         T3 act, bool res) => Assert.Equal(res, await e.EnforceWithMatcherAsync(matcher, sub, obj, act));
-    
-    internal static void TestBatchEnforceWithMatcher<T>(this IEnforcer e, string matcher, IEnumerable<(T, bool)> values) 
-        where T : IRequestValues => 
+
+    internal static void TestBatchEnforceWithMatcher<T>(this IEnforcer e, string matcher, IEnumerable<(T, bool)> values)
+        where T : IRequestValues =>
             Assert.True(values.Select(x => x.Item2).SequenceEqual(e.BatchEnforceWithMatcher(matcher, values.Select(x => x.Item1))));
 
-    internal static void TestBatchEnforceWithMatcherParallel<T>(this Enforcer e, string matcher, IEnumerable<(T, bool)> values) 
-        where T : IRequestValues => 
+    internal static void TestBatchEnforceWithMatcherParallel<T>(this Enforcer e, string matcher, IEnumerable<(T, bool)> values)
+        where T : IRequestValues =>
             Assert.True(values.Select(x => x.Item2).SequenceEqual(e.BatchEnforceWithMatcherParallel<T>(matcher, values.Select(x => x.Item1).ToList())));
 
-    internal static async void TestBatchEnforceWithMatcherAsync<T>(IEnforcer e, string matcher, IEnumerable<(T, bool)> values) 
-        where T : IRequestValues 
+    internal static async void TestBatchEnforceWithMatcherAsync<T>(IEnforcer e, string matcher, IEnumerable<(T, bool)> values)
+        where T : IRequestValues
     {
 #if !NET452
         var res = e.BatchEnforceWithMatcherAsync(matcher, values.Select(x => x.Item1));
@@ -80,7 +80,7 @@ public static class TestUtil
         var expectedResults = values.Select(x => x.Item2);
         var expectedResultEnumerator = expectedResults.GetEnumerator();
 #if !NET452
-        await foreach(var item in res)
+        await foreach (var item in res)
 #else
         foreach(var item in res)
 #endif
@@ -248,7 +248,7 @@ public static class TestUtil
 
     internal delegate IEnumerable<string> GetAllList();
 
-    #region RoleManger test
+    #region RoleManager test
 
     internal static void TestRole(IRoleManager roleManager, string name1, string name2, bool expectResult)
     {

--- a/Casbin/Extensions/Enforcer/EnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/EnforcerExtension.cs
@@ -328,7 +328,7 @@ namespace Casbin
         }
 
         public static IRoleManager GetRoleManager(this IEnforcer enforcer, string roleType) =>
-            enforcer.Model.GetRoleManger(roleType);
+            enforcer.Model.GetRoleManager(roleType);
 
         public static void SetRoleManager(this IEnforcer enforcer, IRoleManager roleManager) =>
             enforcer.SetRoleManager(PermConstants.DefaultRoleType, roleManager);
@@ -355,13 +355,13 @@ namespace Casbin
         public static void AddNamedMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
-            enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);
+            enforcer.Model.GetRoleManager(roleType).AddMatchingFunc(func);
         }
 
         public static void AddNamedDomainMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
-            enforcer.Model.GetRoleManger(roleType).AddMatchingFunc(func);
+            enforcer.Model.GetRoleManager(roleType).AddMatchingFunc(func);
         }
 
         #endregion

--- a/Casbin/Extensions/Enforcer/EnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/EnforcerExtension.cs
@@ -361,7 +361,7 @@ namespace Casbin
         public static void AddNamedDomainMatchingFunc(this IEnforcer enforcer, string roleType,
             Func<string, string, bool> func)
         {
-            enforcer.Model.GetRoleManager(roleType).AddMatchingFunc(func);
+            enforcer.Model.GetRoleManager(roleType).AddDomainMatchingFunc(func);
         }
 
         #endregion

--- a/Casbin/Extensions/Enforcer/InternalEnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/InternalEnforcerExtension.cs
@@ -46,7 +46,7 @@ namespace Casbin
         internal static bool InternalAddPolicy(this IEnforcer enforcer, string section, string policyType,
             IPolicyValues values)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             bool ruleAdded = policyManager.AddPolicy(values);
 
             if (ruleAdded is false)
@@ -69,13 +69,13 @@ namespace Casbin
         internal static async Task<bool> InternalAddPolicyAsync(this IEnforcer enforcer, string section,
             string policyType, IPolicyValues values)
         {
-            IPolicyManager policyManger = enforcer.Model.GetPolicyManger(section, policyType);
-            if (policyManger.HasPolicy(values))
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
+            if (policyManager.HasPolicy(values))
             {
                 return false;
             }
 
-            bool ruleAdded = await policyManger.AddPolicyAsync(values);
+            bool ruleAdded = await policyManager.AddPolicyAsync(values);
 
             if (ruleAdded is false)
             {
@@ -97,7 +97,7 @@ namespace Casbin
         internal static bool InternalAddPolicies(this IEnforcer enforcer, string section, string policyType,
             IReadOnlyList<IPolicyValues> valuesList)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicies(valuesList))
             {
                 return false;
@@ -126,7 +126,7 @@ namespace Casbin
         internal static async Task<bool> InternalAddPoliciesAsync(this IEnforcer enforcer, string section,
             string policyType, IReadOnlyList<IPolicyValues> valuesList)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicies(valuesList))
             {
                 return false;
@@ -156,7 +156,7 @@ namespace Casbin
         internal static bool InternalUpdatePolicy(this IEnforcer enforcer, string section, string policyType,
             IPolicyValues oldValues, IPolicyValues newValues)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicy(oldValues) is false)
             {
                 return false;
@@ -186,7 +186,7 @@ namespace Casbin
         internal static async Task<bool> InternalUpdatePolicyAsync(this IEnforcer enforcer, string section,
             string policyType, IPolicyValues oldValues, IPolicyValues newValues)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicy(oldValues) is false)
             {
                 return false;
@@ -216,7 +216,7 @@ namespace Casbin
         internal static bool InternalUpdatePolicies(this IEnforcer enforcer, string section, string policyType,
             IReadOnlyList<IPolicyValues> oldValuesList, IReadOnlyList<IPolicyValues> newValuesList)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasAllPolicies(oldValuesList) is false)
             {
                 return false;
@@ -246,7 +246,7 @@ namespace Casbin
         internal static async Task<bool> InternalUpdatePoliciesAsync(this IEnforcer enforcer, string section,
             string policyType, IReadOnlyList<IPolicyValues> oldValuesList, IReadOnlyList<IPolicyValues> newValuesList)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasAllPolicies(oldValuesList) is false)
             {
                 return false;
@@ -275,7 +275,7 @@ namespace Casbin
         internal static bool InternalRemovePolicy(this IEnforcer enforcer, string section, string policyType,
             IPolicyValues values)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicy(values) is false)
             {
                 return false;
@@ -303,7 +303,7 @@ namespace Casbin
         internal static async Task<bool> InternalRemovePolicyAsync(this IEnforcer enforcer, string section,
             string policyType, IPolicyValues rule)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicy(rule) is false)
             {
                 return false;
@@ -331,7 +331,7 @@ namespace Casbin
         internal static bool InternalRemovePolicies(this IEnforcer enforcer, string section, string policyType,
             IReadOnlyList<IPolicyValues> rules)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicies(rules) is false)
             {
                 return false;
@@ -359,7 +359,7 @@ namespace Casbin
         internal static async Task<bool> InternalRemovePoliciesAsync(this IEnforcer enforcer, string section,
             string policyType, IReadOnlyList<IPolicyValues> rules)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             if (policyManager.HasPolicies(rules) is false)
             {
                 return false;
@@ -389,7 +389,7 @@ namespace Casbin
         internal static bool InternalRemoveFilteredPolicy(this IEnforcer enforcer, string section, string policyType,
             int fieldIndex, IPolicyValues fieldValues)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             IEnumerable<IPolicyValues> effectPolicies = policyManager.RemoveFilteredPolicy(fieldIndex, fieldValues);
 
             if (effectPolicies is null)
@@ -416,7 +416,7 @@ namespace Casbin
         internal static async Task<bool> InternalRemoveFilteredPolicyAsync(this IEnforcer enforcer, string section,
             string policyType, int fieldIndex, IPolicyValues fieldValues)
         {
-            IPolicyManager policyManager = enforcer.Model.GetPolicyManger(section, policyType);
+            IPolicyManager policyManager = enforcer.Model.GetPolicyManager(section, policyType);
             IEnumerable<IPolicyValues> effectPolicies =
                 await policyManager.RemoveFilteredPolicyAsync(fieldIndex, fieldValues);
 

--- a/Casbin/Extensions/Enforcer/RbacEnforcerExtension.cs
+++ b/Casbin/Extensions/Enforcer/RbacEnforcerExtension.cs
@@ -55,8 +55,8 @@ namespace Casbin
         public static IEnumerable<string> GetRolesForUser(this IEnforcer enforcer, string name, string domain = null)
         {
             return domain is null
-                ? enforcer.Model.GetRoleManger().GetRoles(name)
-                : enforcer.Model.GetRoleManger().GetRoles(name, domain);
+                ? enforcer.Model.GetRoleManager().GetRoles(name)
+                : enforcer.Model.GetRoleManager().GetRoles(name, domain);
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace Casbin
         public static IEnumerable<string> GetUsersForRole(this IEnforcer enforcer, string name, string domain = null)
         {
             return domain is null
-                ? enforcer.Model.GetRoleManger().GetUsers(name)
-                : enforcer.Model.GetRoleManger().GetUsers(name, domain);
+                ? enforcer.Model.GetRoleManager().GetUsers(name)
+                : enforcer.Model.GetRoleManager().GetUsers(name, domain);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Casbin
             var userIds = new List<string>();
             foreach (string name in names)
             {
-                userIds.AddRange(enforcer.Model.GetRoleManger().GetUsers(name));
+                userIds.AddRange(enforcer.Model.GetRoleManager().GetUsers(name));
             }
 
             return userIds;
@@ -649,7 +649,7 @@ namespace Casbin
             string roleType = null)
         {
             roleType ??= PermConstants.DefaultRoleType;
-            return enforcer.Model.GetRoleManger(roleType).GetDomains(name);
+            return enforcer.Model.GetRoleManager(roleType).GetDomains(name);
         }
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace Casbin
         /// <returns></returns>
         public static IEnumerable<string>
             GetRolesForUserInDomain(this IEnforcer enforcer, string name, string domain) =>
-            enforcer.Model.GetRoleManger().GetRoles(name, domain);
+            enforcer.Model.GetRoleManager().GetRoles(name, domain);
 
         /// <summary>
         ///

--- a/Casbin/Extensions/Model/ModelExtension.cs
+++ b/Casbin/Extensions/Model/ModelExtension.cs
@@ -205,12 +205,12 @@ namespace Casbin.Model
             }
         }
 
-        public static IPolicyManager GetPolicyManger(this IModel model, string section,
+        public static IPolicyManager GetPolicyManager(this IModel model, string section,
             string policyType = PermConstants.DefaultPolicyType) =>
             model.Sections.GetPolicyAssertion(section, policyType).PolicyManager;
 
         public static IRoleManager
-            GetRoleManger(this IModel model, string roleType = PermConstants.DefaultRoleType) =>
+            GetRoleManager(this IModel model, string roleType = PermConstants.DefaultRoleType) =>
             model.Sections.GetRoleAssertion(roleType).RoleManager;
 
         public static void SetRoleManager(this IModel model, string roleType, IRoleManager roleManager)

--- a/Casbin/Extensions/Rbac/RoleManagerExtension.cs
+++ b/Casbin/Extensions/Rbac/RoleManagerExtension.cs
@@ -3,7 +3,7 @@ using Casbin.Rbac;
 
 namespace Casbin
 {
-    public static class RoleMangerExtension
+    public static class RoleManagerExtension
     {
         public static IRoleManager AddMatchingFunc(this IRoleManager roleManager,
             Func<string, string, bool> matchingFunc)


### PR DESCRIPTION
The extension function to add a domain matching func was calling the wrong role manager method.  This resolves the issue. I also fixed a spelling error from `Manger` -> `Manager` across the repo 

