### PR TITLE
fix: concurrent access issues with HashSet<string>

### DIFF
--- a/Casbin.UnitTests/Fixtures/TestModelFixture.cs
+++ b/Casbin.UnitTests/Fixtures/TestModelFixture.cs
@@ -16,6 +16,9 @@ public class TestModelFixture
     public static readonly string BasicWithoutUserPolicyText = ReadTestFile("basic_without_users_policy.csv");
     public static readonly string BasicWithRootModelText = ReadTestFile("basic_with_root_model.conf");
 
+    public static readonly string SaaRbacModelText = ReadTestFile("saa_model.conf");
+    public static readonly string SaaRbacPolicyText = ReadTestFile("saa_rbac_policy.csv");
+
     public static readonly string RbacPolicyText = ReadTestFile("rbac_policy.csv");
     public static readonly string RbacCommentText = ReadTestFile("rbac_comment.conf");
     public static readonly string RbacInOperatorModelText = ReadTestFile("rbac_in_operator_model.conf");
@@ -118,6 +121,8 @@ public class TestModelFixture
 
     public static IModel GetNewPriorityExplicitDenyOverrideModel() => GetNewTestModel(PriorityExplicitDenyOverrideModelText,
         PriorityExplicitDenyOverridePolicyText);
+
+    public static IModel GetNewSaaRbacTestModel() => GetNewTestModel(SaaRbacModelText, SaaRbacPolicyText);
 
     public static IModel GetNewRbacTestModel() => GetNewTestModel(RbacModelText, RbacPolicyText);
 

--- a/Casbin.UnitTests/examples/saa_model.conf
+++ b/Casbin.UnitTests/examples/saa_model.conf
@@ -1,0 +1,17 @@
+[request_definition]
+# request includes subject, domain parent of obj, object requesting access for, action requested
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, act
+
+[role_definition]
+g = _, _
+g2 = _, _
+g3 = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && (g2(r.dom, p.dom) || r.obj == p.dom) && g3(r.act, p.act)

--- a/Casbin.UnitTests/examples/saa_rbac_policy.csv
+++ b/Casbin.UnitTests/examples/saa_rbac_policy.csv
@@ -1,0 +1,3 @@
+# sample policy, not needed for test
+p, tellers, banks/1, wager-editor
+

--- a/Casbin/Model/DefaultPolicyStore.Node.cs
+++ b/Casbin/Model/DefaultPolicyStore.Node.cs
@@ -34,7 +34,17 @@ public partial class DefaultPolicyStore
             Interlocked.Exchange(ref Policy, valuesList);
 
         public bool ContainsPolicy(IPolicyValues values)
-            => PolicyTextSet.Contains(values.ToText());
+        {
+            Lock.EnterReadLock();
+            try
+            {
+                return PolicyTextSet.Contains(values.ToText());
+            }
+            finally
+            {
+                Lock.ExitReadLock();
+            }
+        }
 
         public bool ValidatePolicy(IPolicyValues values)
         {
@@ -67,13 +77,13 @@ public partial class DefaultPolicyStore
             try
             {
                 Policy.Add(values);
+                PolicyTextSet.Add(values.ToText());
             }
             finally
             {
                 Lock.ExitWriteLock();
             }
 
-            PolicyTextSet.Add(values.ToText());
             return true;
         }
 
@@ -244,13 +254,13 @@ public partial class DefaultPolicyStore
             {
                 int lastIndex = Policy.FindLastIndex(LastLessOrEqualPriority);
                 Policy.Insert(lastIndex + 1, values);
+                PolicyTextSet.Add(values.ToText());
             }
             finally
             {
                 Lock.ExitWriteLock();
             }
 
-            PolicyTextSet.Add(values.ToText());
             return true;
         }
 


### PR DESCRIPTION
Came across issues that are similar to https://github.com/casbin/Casbin.NET/issues/336

Was able to create a concurrent update of the grouping policy which would trigger concurrent access errors.  It would work OK with only 100, but once you hit 500 or greater it would fail almost 100% of the time.

I don't think this should go into `master` as-is, but one of your members can take what is here and make the appropriate changes to handle the access.  You can remove my code changes and just use the test and models to see the test fail.